### PR TITLE
chore: sync obsidian-brain to v1.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
       "name": "obsidian-brain",
       "source": "./plugins/obsidian-brain",
       "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, and enables project-scoped context resume via structured markdown notes.",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     {
       "name": "product-video-creation",

--- a/plugins/obsidian-brain/.claude-plugin/plugin.json
+++ b/plugins/obsidian-brain/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/plugins/obsidian-brain/CHANGELOG.md
+++ b/plugins/obsidian-brain/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-04-07
+
+### Fixed
+- `/recall` now produces accurate summaries for long sessions. Previously the raw session note was truncated to ~40 conversation turns and `/recall` summarized only that slice; now `/recall` deterministically locates the original Claude Code transcript JSONL by `session_id` and re-parses it when it has more data than the raw note. Very large transcripts (>5 MB) are sliced into head+tail halves with an explicit warning surfaced to the user. Falls back gracefully when the JSONL is no longer on disk.
+
+### Changed
+- Raw session notes now keep more context standalone — `build_raw_fallback()` caps bumped: 120 conversation turns (was 40), 1200 chars per message (was 600), 80 tool uses (was 30), 60 files touched (was 30), 30 errors (was 15). Typical sessions remain self-contained without needing the JSONL fallback.
+
 ## [1.6.0] - 2026-04-07
 
 ### Added

--- a/plugins/obsidian-brain/hooks/obsidian_utils.py
+++ b/plugins/obsidian-brain/hooks/obsidian_utils.py
@@ -26,6 +26,13 @@ from pathlib import Path
 # Default configuration
 # ---------------------------------------------------------------------------
 
+# Shared cap for the raw-note conversation section. Used by build_raw_fallback
+# as the write-time truncation limit, and returned by parse_full_transcript
+# so /recall can deterministically detect truncation by comparing the parsed
+# message total against it — avoiding any dependence on the raw note's
+# message-filtering heuristics.
+RAW_NOTE_MAX_TURNS = 120
+
 _CONFIG_PATH = Path.home() / ".claude" / "obsidian-brain-config.json"
 
 _DEFAULTS: dict = {
@@ -219,11 +226,46 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
         except Exception:
             pass
 
-    # --- Files touched: extract from tool_use blocks (Edit/Write/MultiEdit) ---
+    # --- Files touched + Errors: delegate to shared helpers ---
+    meta["files_touched"] = _extract_files_touched(messages)[:60]
+    meta["errors"] = _extract_errors(messages)[:30]
+
+    return meta
+
+
+def _entry_content(entry: dict) -> str | list | None:
+    """Return the raw transcript content value for an entry.
+
+    Supports both the canonical CC JSONL shape (nested under
+    entry['message']['content']) and the flat fallback shape
+    (entry['content'] directly). Mirrors the shape handling of
+    extract_user_messages / extract_assistant_messages so the
+    _extract_* helpers below stay consistent across transcript formats.
+
+    Return value is whatever the transcript stored — typically a
+    list of content blocks (for tool-use / text / tool_result blocks)
+    but can also be a plain string in flat-format transcripts, or
+    None when no content is present. Callers must `isinstance` check
+    before iterating.
+    """
+    msg = entry.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if content is not None:
+            return content
+    return entry.get("content")
+
+
+def _extract_files_touched(messages: list[dict]) -> list[str]:
+    """Extract unique file paths from Edit/Write/MultiEdit tool_use blocks.
+
+    Shared between extract_session_metadata (SessionEnd write path) and
+    parse_full_transcript (/recall read path) to prevent drift. Handles
+    both CC and flat transcript shapes via _entry_content.
+    """
     files_seen: list[str] = []
     for entry in messages:
-        msg = entry.get("message", {})
-        content = msg.get("content") if isinstance(msg, dict) else None
+        content = _entry_content(entry)
         if not isinstance(content, list):
             continue
         for block in content:
@@ -234,18 +276,23 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
                 "Write",
                 "MultiEdit",
             ):
-                inp = block.get("input", {})
-                if isinstance(inp, dict):
-                    fp = inp.get("file_path", "")
-                    if fp and fp not in files_seen:
-                        files_seen.append(fp)
-    meta["files_touched"] = files_seen[:50]
+                inp = block.get("input") if isinstance(block.get("input"), dict) else {}
+                fp = inp.get("file_path", "")
+                if fp and fp not in files_seen:
+                    files_seen.append(fp)
+    return files_seen
 
-    # --- Errors: extract from tool_result blocks with is_error ---
+
+def _extract_errors(messages: list[dict]) -> list[str]:
+    """Extract unique error snippets from tool_result blocks with is_error=true.
+
+    Shared between extract_session_metadata (SessionEnd write path) and
+    parse_full_transcript (/recall read path) to prevent drift. Handles
+    both CC and flat transcript shapes via _entry_content.
+    """
     errors: list[str] = []
     for entry in messages:
-        msg = entry.get("message", {})
-        content = msg.get("content") if isinstance(msg, dict) else None
+        content = _entry_content(entry)
         if not isinstance(content, list):
             continue
         for block in content:
@@ -257,9 +304,7 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
                     snippet = err_content.strip()[:200]
                     if snippet not in errors:
                         errors.append(snippet)
-    meta["errors"] = errors[:20]
-
-    return meta
+    return errors
 
 
 # ---------------------------------------------------------------------------
@@ -516,11 +561,13 @@ def extract_tool_uses(messages: list[dict]) -> list[dict]:
     """Extract tool usage details from transcript for the raw fallback note.
 
     Returns a list of dicts: [{"name": "Edit", "detail": "file.py:10-20"}, ...]
+
+    Handles both the canonical CC JSONL shape (entry['message']['content'])
+    and the flat fallback shape (entry['content']) via _entry_content.
     """
     tool_uses: list[dict] = []
     for entry in messages:
-        msg = entry.get("message", {})
-        content = msg.get("content") if isinstance(msg, dict) else None
+        content = _entry_content(entry)
         if not isinstance(content, list):
             continue
         for block in content:
@@ -563,6 +610,297 @@ def get_project_name(cwd: str) -> str:
     return Path(cwd).name if cwd else "unknown"
 
 
+def find_transcript_jsonl(session_id: str) -> Path | None:
+    """Locate the original Claude Code transcript JSONL by session_id.
+
+    Returns the Path if found, None otherwise. Uses find(1) so it is
+    agnostic to project-path encoding (hyphens vs underscores).
+    """
+    if not session_id or session_id == "unknown":
+        return None
+    projects_dir = Path.home() / ".claude" / "projects"
+    if not projects_dir.is_dir():
+        return None
+    # Reject any session_id containing glob metacharacters, path separators,
+    # or whitespace. `find -name` matches basenames and treats its argument
+    # as a glob, so separators would never match and metacharacters would
+    # match the wrong file. UUIDs never contain any of these — an occurrence
+    # indicates garbage input rather than a legitimate lookup.
+    if any(c in session_id for c in "*?[]/\\ \t\n\r"):
+        return None
+    target = f"{session_id}.jsonl"
+    # Primary path: external `find` with -print -quit (fast on large trees).
+    # Suppress stderr so permission-denied or other noise on unrelated
+    # subtrees does not poison the exit code. Use stdout whenever it's
+    # non-empty regardless of returncode — `find` commonly returns non-zero
+    # after encountering a restricted directory even when it also printed a
+    # legitimate match from a sibling directory.
+    try:
+        result = subprocess.run(
+            ["find", str(projects_dir), "-name", target, "-type", "f", "-print", "-quit"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=5,
+        )
+        if result.stdout.strip():
+            first = result.stdout.strip().split("\n")[0]
+            return Path(first) if first else None
+    except subprocess.TimeoutExpired:
+        # If `find` already timed out on this tree, a pure-Python rglob
+        # will almost certainly be slower — the tree is too large. Treat
+        # timeout as a hard failure so /recall falls back to the raw note
+        # rather than hanging on a worse scan.
+        return None
+    except FileNotFoundError:
+        # `find` not on PATH (sandboxed/minimal container). Fall through
+        # to the pure-Python rglob fallback below.
+        pass
+    except OSError:
+        pass
+
+    # Fallback: pure-Python rglob. Only reached when `find` is unavailable,
+    # never when it timed out. Dependency-free so /recall still works in
+    # sandboxed environments that don't ship with `find`.
+    try:
+        for path in projects_dir.rglob(target):
+            if path.is_file():
+                return path
+    except OSError:
+        return None
+    return None
+
+
+def parse_full_transcript(jsonl_path: Path, max_bytes: int = 5_000_000) -> dict:
+    """Parse a Claude Code transcript JSONL WITHOUT the raw-note caps.
+
+    Delegates to the canonical extract_user_messages / extract_assistant_messages /
+    extract_tool_uses helpers so tool-use and error detection stay in parity
+    with the SessionEnd write path. Never fails silently on data loss —
+    the returned `warnings` list is the caller's signal for every hiccup.
+
+    Applies a hard byte budget. When the transcript exceeds max_bytes, it
+    is sliced into head + tail halves of the budget; partial lines at the
+    slice boundaries are detected (head not ending on \\n, tail not starting
+    on \\n) and dropped explicitly with a warning.
+
+    Returns a dict with keys:
+        - user_msgs: list[str]
+        - assistant_msgs: list[str]
+        - tool_uses: list[dict]   (same shape as extract_tool_uses output)
+        - files_touched: list[str]
+        - errors: list[str]
+        - truncated: bool          (True if byte budget kicked in)
+        - warnings: list[str]      (visible issues the caller should surface)
+        - raw_note_max_turns: int  (the RAW_NOTE_MAX_TURNS constant, for caller reference)
+        - raw_note_would_truncate: bool  (True iff build_raw_fallback would hit its write cap)
+    """
+    warnings: list[str] = []
+    bad_lines = 0
+    unknown_block_types: set[str] = set()
+    truncated = False
+
+    def _empty_result(warning: str) -> dict:
+        return {
+            "user_msgs": [], "assistant_msgs": [], "tool_uses": [],
+            "files_touched": [], "errors": [], "truncated": False,
+            "warnings": [warning],
+            # Always include the shared cap + derived signal so /recall's
+            # decision logic can key off one consistent schema regardless
+            # of which branch ran. Empty transcripts cannot have truncated.
+            "raw_note_max_turns": RAW_NOTE_MAX_TURNS,
+            "raw_note_would_truncate": False,
+        }
+
+    try:
+        size = jsonl_path.stat().st_size
+    except OSError as exc:
+        return _empty_result(f"Could not stat transcript file: {exc}")
+
+    if size == 0:
+        return _empty_result("Transcript file is empty (0 bytes).")
+
+    if size <= max_bytes:
+        try:
+            with open(jsonl_path, "r", encoding="utf-8", errors="replace") as fh:
+                lines = fh.read().splitlines()
+        except OSError as exc:
+            return _empty_result(f"Could not read transcript file: {exc}")
+    else:
+        # Slice head + tail of the byte budget. Boundary-safe: only drop a
+        # line when the slice actually cut it mid-record. If head_bytes
+        # ends on a newline, its last line is complete — keep it.
+        half = max_bytes // 2
+        # Guarantee head and tail do not overlap: tail starts at max(half, size - half).
+        tail_offset = max(half, size - half)
+        # Peek at the byte immediately before tail_offset to determine
+        # whether the tail slice started exactly at the beginning of a
+        # record. If that preceding byte is a newline, tail_offset lies at
+        # a record boundary and the first tail line is complete; otherwise
+        # the record was cut mid-line and the first tail line is partial.
+        # (Checking tail_text[0] == "\n" is wrong — a clean record boundary
+        # means the tail text starts with the first char of a record, not
+        # a newline.)
+        tail_starts_cleanly = False
+        try:
+            with open(jsonl_path, "rb") as fh:
+                head_bytes = fh.read(half)
+                if tail_offset > 0:
+                    fh.seek(tail_offset - 1)
+                    prev_byte = fh.read(1)
+                    tail_starts_cleanly = prev_byte in (b"\n", b"\r")
+                else:
+                    tail_starts_cleanly = True
+                fh.seek(tail_offset)
+                tail_bytes = fh.read()
+        except OSError as exc:
+            return _empty_result(f"Could not slice transcript file: {exc}")
+
+        head_text = head_bytes.decode("utf-8", errors="replace")
+        tail_text = tail_bytes.decode("utf-8", errors="replace")
+        head_lines = head_text.splitlines()
+        tail_lines = tail_text.splitlines()
+        partial_dropped = 0
+        # Drop the last head line only if head_bytes did not end on a newline
+        # (meaning the record is genuinely cut mid-line).
+        if head_lines and not head_text.endswith(("\n", "\r")):
+            head_lines.pop()
+            partial_dropped += 1
+        # Drop the first tail line only if tail_offset did NOT land at a
+        # clean record boundary (byte before tail_offset is not a newline).
+        if tail_lines and not tail_starts_cleanly:
+            tail_lines.pop(0)
+            partial_dropped += 1
+        lines = head_lines + tail_lines
+        truncated = True
+        if partial_dropped:
+            warnings.append(
+                f"Transcript byte budget exceeded ({size} > {max_bytes} bytes) — "
+                f"middle section sliced, {partial_dropped} partial JSONL lines dropped at slice boundaries."
+            )
+        else:
+            warnings.append(
+                f"Transcript byte budget exceeded ({size} > {max_bytes} bytes) — "
+                f"middle section sliced (both slice boundaries fell on record boundaries cleanly)."
+            )
+
+    # First pass: collect parsed JSONL records into an entries list. The
+    # downstream extract_* helpers accept both the canonical CC shape
+    # (top-level `type` plus nested `message.content`) and the flat
+    # fallback shape, so no explicit normalization is needed here.
+    entries: list[dict] = []
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            bad_lines += 1
+            continue
+        if not isinstance(obj, dict):
+            bad_lines += 1
+            continue
+        entries.append(obj)
+        # Collect any unexpected content block types for user-visible warnings.
+        msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    btype = block.get("type")
+                    if btype and btype not in (
+                        "text", "tool_use", "tool_result", "thinking",
+                        "image", "redacted_thinking",
+                    ):
+                        unknown_block_types.add(btype)
+
+    # Delegate to canonical helpers so behavior stays in parity with the
+    # SessionEnd write path.
+    user_msgs = extract_user_messages(entries)
+    assistant_msgs = extract_assistant_messages(entries)
+    tool_uses = extract_tool_uses(entries)
+
+    # Files touched + errors: delegate to the shared helpers used by
+    # extract_session_metadata so both code paths stay in lockstep.
+    # No caps applied here — caps belong to the display layer, not
+    # re-parse, so the full summary can see everything the transcript
+    # actually contains.
+    files_seen = _extract_files_touched(entries)
+    errors = _extract_errors(entries)
+
+    # Note: we do not inject a "[... middle truncated ...]" marker into
+    # user_msgs. At this point it would land at the very end of the list
+    # (after the tail slice), not at the actual head/tail boundary, which
+    # would be misleading. The slice is already surfaced via `truncated`
+    # and the `warnings` list, which is what the caller uses for display.
+
+    if bad_lines:
+        warnings.append(f"{bad_lines} malformed JSONL line(s) skipped while re-parsing transcript.")
+    if unknown_block_types:
+        warnings.append(
+            f"Unknown content block types encountered (data may be incomplete): {', '.join(sorted(unknown_block_types))}"
+        )
+
+    # Simulate the exact write loop in build_raw_fallback to determine
+    # whether the raw fallback would have truncated. This is the only
+    # fully deterministic signal: the cap applies to lines actually
+    # written, and filtered system-noise user messages do not increment
+    # the counter. Simple parsed_total > cap comparison can false-positive
+    # when noise filtering gives headroom.
+    raw_note_would_truncate = _would_raw_fallback_truncate(user_msgs, assistant_msgs)
+
+    return {
+        "user_msgs": user_msgs,
+        "assistant_msgs": assistant_msgs,
+        "tool_uses": tool_uses,
+        "files_touched": files_seen,
+        "errors": errors,
+        "truncated": truncated,
+        "warnings": warnings,
+        # The raw-note cap constant, preserved for backward compatibility
+        # with callers that still want to inspect it.
+        "raw_note_max_turns": RAW_NOTE_MAX_TURNS,
+        # Definitive signal: true iff build_raw_fallback would have hit
+        # its write cap before consuming all user+assistant messages.
+        # This is what /recall should branch on.
+        "raw_note_would_truncate": raw_note_would_truncate,
+    }
+
+
+def _would_raw_fallback_truncate(
+    user_msgs: list[str], assistant_msgs: list[str]
+) -> bool:
+    """Return True iff build_raw_fallback's write loop would hit its
+    RAW_NOTE_MAX_TURNS cap before consuming all user+assistant messages.
+
+    Mirrors the exact loop in build_raw_fallback so the signal is
+    deterministic: filtered system-noise user messages do not count
+    toward the cap, so a transcript with more total messages than the
+    cap may still fit entirely when enough noise is filtered out.
+    """
+    max_turns = RAW_NOTE_MAX_TURNS
+    u_idx, a_idx = 0, 0
+    turn = 0
+    while turn < max_turns and (
+        u_idx < len(user_msgs)
+        or (assistant_msgs and a_idx < len(assistant_msgs))
+    ):
+        if u_idx < len(user_msgs):
+            snippet = user_msgs[u_idx][:1200].replace("\n", " ")
+            # Same filter as build_raw_fallback: skip system noise.
+            if not (
+                snippet.startswith("<task-notification>")
+                or snippet.startswith("Base directory for this skill:")
+                or snippet.startswith("<local-command")
+            ):
+                turn += 1
+            u_idx += 1
+        if assistant_msgs and a_idx < len(assistant_msgs):
+            a_idx += 1
+            turn += 1
+    # Truncated iff the loop bailed on the cap with inputs remaining.
+    return u_idx < len(user_msgs) or a_idx < len(assistant_msgs)
+
+
 def build_raw_fallback(
     user_msgs: list[str],
     metadata: dict,
@@ -591,7 +929,7 @@ def build_raw_fallback(
     sections.append("## Changes Made")
     files = metadata.get("files_touched", [])
     if files:
-        for f in files[:30]:
+        for f in files[:60]:
             sections.append(f"- `{f}`")
     else:
         sections.append("None detected.")
@@ -600,7 +938,7 @@ def build_raw_fallback(
     # Tool usage details (commands run, files edited)
     if tool_uses:
         sections.append("## Tool Usage")
-        for tu in tool_uses[:30]:
+        for tu in tool_uses[:80]:
             name = tu.get("name", "")
             detail = tu.get("detail", "")
             if name and detail:
@@ -612,7 +950,7 @@ def build_raw_fallback(
     sections.append("## Errors Encountered")
     errors = metadata.get("errors", [])
     if errors:
-        for e in errors[:15]:
+        for e in errors[:30]:
             sections.append(f"- {e}")
     else:
         sections.append("None.")
@@ -623,19 +961,19 @@ def build_raw_fallback(
 
     # Interleaved conversation for /recall to summarize
     sections.append("## Conversation (raw)")
-    max_turns = 40
+    max_turns = RAW_NOTE_MAX_TURNS
     u_idx, a_idx = 0, 0
     turn = 0
     while turn < max_turns and (u_idx < len(user_msgs) or (assistant_msgs and a_idx < len(assistant_msgs))):
         if u_idx < len(user_msgs):
-            snippet = user_msgs[u_idx][:600].replace("\n", " ")
+            snippet = user_msgs[u_idx][:1200].replace("\n", " ")
             # Skip system noise (task notifications, command loading, etc.)
             if not snippet.startswith("<task-notification>") and not snippet.startswith("Base directory for this skill:") and not snippet.startswith("<local-command"):
                 sections.append(f"**User:** {snippet}")
                 turn += 1
             u_idx += 1
         if assistant_msgs and a_idx < len(assistant_msgs):
-            snippet = assistant_msgs[a_idx][:600].replace("\n", " ")
+            snippet = assistant_msgs[a_idx][:1200].replace("\n", " ")
             sections.append(f"**Assistant:** {snippet}")
             a_idx += 1
             turn += 1

--- a/plugins/obsidian-brain/skills/recall/SKILL.md
+++ b/plugins/obsidian-brain/skills/recall/SKILL.md
@@ -41,9 +41,9 @@ basename "$(pwd)"
 
 Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
 
-### Step 3 — Summarize unsummarized notes (deferred summarization)
+### Step 3 — Summarize unsummarized notes (deferred summarization, truncation-aware)
 
-This is the critical upgrade step. Search for raw/unsummarized session notes matching this project.
+This is the critical upgrade step. Search for raw/unsummarized session notes matching this project, and prefer the original Claude Code transcript JSONL over the truncated raw note when the JSONL has more data.
 
 Use Grep to find notes containing the "AI summary unavailable" marker in the sessions folder:
 
@@ -63,29 +63,68 @@ output_mode: content
 
 For each file that matches BOTH conditions (unsummarized AND belongs to this project):
 
-1. **Read the full file** using the Read tool.
-2. **Extract frontmatter** — preserve it exactly as-is (everything between the opening `---` and closing `---`).
-3. **Extract the full conversation** — look for all content after frontmatter. The raw note now includes:
-   - `## Conversation (raw)` — interleaved user and assistant messages
-   - `## Tool Usage` — commands run, files edited, searches performed
-   - `## Changes Made` — files touched (from tool_use extraction)
-   - `## Errors Encountered` — errors from tool results
-   Read ALL of these sections — they provide the context needed for a high-quality summary.
+1. **Read the raw note in full** with the Read tool. Preserve frontmatter exactly. Extract the `session_id` value from the frontmatter and **store it as `SESSION_ID`** — the Bash snippet in sub-step 3 references this exact variable name.
 
-4. **Generate a detailed, specific summary** from the raw content. Be precise — include file paths, function names, config values, and technical specifics. Produce these sections:
-   - `## Summary` — 3-5 sentence overview. Include: what problem was being solved, what approach was taken, what was the outcome. Name specific technologies, files, and patterns.
-   - `## Key Decisions` — Bulleted list with rationale. Each bullet should explain the decision AND why it was made (e.g., "Chose Redis over Memcached for session store — needed TTL per key for token expiry"). If none, write "None noted."
-   - `## Changes Made` — Bulleted list with file paths and descriptions. Be specific: "Modified `src/auth/handler.ts` — added JWT refresh token rotation with 15min access / 7day refresh windows". Include commit messages if visible. If none, write "None noted."
-   - `## Errors Encountered` — Bulleted list with error messages, root causes, AND fixes. Be specific: "`TypeError: Cannot read property 'token' of undefined` in handler.ts:42 — caused by null user object when session expired, fixed with optional chaining". If none, write "None."
-   - `## Open Questions / Next Steps` — Checkbox list of specific, actionable items. Not vague ("improve performance") but concrete ("Add rate limiting to /api/auth/refresh endpoint, max 10 req/min per user"). If none, write "None."
-5. **Preserve the Session Metadata section** at the bottom if it exists (commits, files touched).
-6. **Write the upgraded note** using the Write tool — same file path. The structure must be:
-   - Original frontmatter (unchanged)
+2. **No raw-note turn count needed.** Earlier revisions of this skill counted `^\*\*User:\*\*` / `^\*\*Assistant:\*\*` markers in the raw note to detect truncation, but that count is unreliable. The raw fallback's `## Conversation (raw)` section filters out system noise (`<task-notification>`, `<local-command…>`, "Base directory for this skill:", …) before emitting a `**User:**` line. Its `turn` counter is incremented whenever a `**User:**` OR `**Assistant:**` line is actually written, with user lines sometimes skipped due to noise filtering. So the marker count in a written raw note does not necessarily correspond to the underlying user/assistant message count in the transcript — filtered user messages are invisible. Use the shared `raw_note_max_turns` constant returned by the helper in sub-step 3 instead — it is the only deterministic truncation signal.
+
+3. **Locate the source JSONL and re-parse it in one shot.** Invoke the helper via argv (no shell interpolation of paths — pass `SESSION_ID` as an argument so session_ids with unusual characters cannot break the quoting). The parsed JSON is printed directly to stdout — no temp files, no traps:
+
+   Run the following Bash command from the obsidian-brain project root. It prints the parsed transcript JSON **directly to stdout** — no temp files, no traps, no `$TMPFILE` that would need to persist across tool invocations. Capture the stdout from the Bash tool result in the next step:
+
+   ```bash
+   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+   python3 -c '
+   import sys, json
+   sys.path.insert(0, "hooks")
+   from obsidian_utils import find_transcript_jsonl, parse_full_transcript, RAW_NOTE_MAX_TURNS
+   p = find_transcript_jsonl(sys.argv[1])
+   if p is None:
+       # Emit the same schema as the success branch so downstream steps
+       # do not need to special-case missing fields. All fields present,
+       # lists empty, booleans False.
+       print(json.dumps({
+           "jsonl_path": None,
+           "user_msgs": [], "assistant_msgs": [], "tool_uses": [],
+           "files_touched": [], "errors": [],
+           "truncated": False,
+           "warnings": [],
+           "raw_note_max_turns": RAW_NOTE_MAX_TURNS,
+           "raw_note_would_truncate": False,
+       }))
+   else:
+       data = parse_full_transcript(p)
+       data["jsonl_path"] = str(p)
+       print(json.dumps(data))
+   ' "$SESSION_ID"
+   ```
+
+   The Bash tool's stdout result is the JSON payload. Parse it directly from the tool response — it contains either `{"jsonl_path": null}` (not found) or the full parsed transcript plus `jsonl_path`, `truncated`, and `warnings`. Very large transcripts can produce multi-MB JSON; if the Bash tool truncates the output, fall back to writing to a known path such as `$VAULT_PATH/.obsidian-brain-transcript-cache.json` and reading it with the Read tool (this file is not in the vault's git repo and is safe to overwrite).
+
+4. **Decide which source to summarize from.** Two independent signals mean "raw note is incomplete":
+   - **`raw_note_would_truncate: true`** — `parse_full_transcript` simulates the exact same write loop as `build_raw_fallback` (including the system-noise filter that skips filtered user messages without incrementing the cap counter). This field is true iff that simulation would have bailed on the cap before consuming all messages. It is the fully deterministic signal — immune to false positives from noise filtering or false negatives from cap drift.
+   - **`truncated: true`** — the transcript exceeded the 5 MB byte budget and was sliced into head+tail halves. In that case some real content is missing from the middle regardless of the cap simulation, so this must be OR'd with the cap signal.
+
+   Decision branches:
+   - **`jsonl_path` is null** → use the raw note as the input. Append to the Summary section: `_(Source transcript not found on disk — summary built from the raw session note; fidelity depends on whether the raw note was itself capped at write time.)_`
+   - **`jsonl_path` is set AND (`raw_note_would_truncate == true` OR `truncated == true`)** → re-parse path engages. Use the parsed `user_msgs`, `assistant_msgs`, `tool_uses`, `files_touched`, and `errors` as the summarization input. If `truncated == true`, note that the summary reflects only the head and tail of the transcript.
+   - **`jsonl_path` is set AND `raw_note_would_truncate == false` AND `truncated == false`** → the raw note captured everything; use it instead.
+   - **If the parsed data's `warnings` list is non-empty** (regardless of which branch), prepend a visible callout section `## ⚠️ Transcript re-parse warnings` at the top of the upgraded note (above `# <title>`), listing each warning as a bullet. This surfaces partial-line losses, malformed JSONL records, unknown block types, and byte-budget slicing so the user knows what's in the summary and what isn't.
+
+5. **Generate a detailed, specific summary** from whichever input source was chosen above. Be precise — include file paths, function names, config values, and technical specifics. Produce these sections (unchanged from before):
+   - `## Summary` — 3-5 sentences
+   - `## Key Decisions` — bulleted list with rationale
+   - `## Changes Made` — bulleted list with file paths
+   - `## Errors Encountered` — bulleted list with messages, root causes, fixes
+   - `## Open Questions / Next Steps` — checkbox list of concrete actionable items
+
+6. **Write the upgraded note** with the Write tool to the same file path. Preserve original frontmatter unchanged but flip `status: auto-logged` to `status: summarized`. Structure:
+   - Original frontmatter (unchanged except `status`)
    - `# <title from original note>`
-   - The five summary sections generated above
-   - The Session Metadata section (if it existed)
+   - The five summary sections
+   - The existing `## Tool Usage` / `## Changes Made` / `## Errors Encountered` / `## Conversation (raw)` sections from the raw note (preserve them as the audit trail — only the leading summary changes)
+   - The Session Metadata section if present
 
-**Important:** Do NOT modify frontmatter. Do NOT change the filename. Do NOT add or remove tags.
+**Important:** Do NOT modify frontmatter fields other than `status`. Do NOT change the filename. Do NOT add or remove tags.
 
 If no unsummarized notes are found for this project, skip to Step 4.
 


### PR DESCRIPTION
Syncs obsidian-brain plugin to v1.6.1 — truncation-aware /recall for long sessions.

- Re-parses the original Claude Code transcript JSONL when the raw session note was capped at write time, so long-session summaries reflect the whole session instead of just the first ~40 turns.
- Bumped raw-note caps so typical sessions stay self-contained without needing the fallback.
- Graceful fallback when the source transcript is no longer on disk.

Source: https://github.com/abhattacherjee/obsidian-brain/releases/tag/v1.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)