### PR TITLE
Sync obsidian-brain v2.4.2 + monorepo v3.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
       "name": "obsidian-brain",
       "source": "./plugins/obsidian-brain",
       "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata.",
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     {
       "name": "product-video-creation",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Each skill also maintains its own `CHANGELOG.md` within its directory.
 
 Format: Monorepo-level events only. For per-skill change details, see `<skill>/CHANGELOG.md`.
 
+## [3.7.0] - 2026-04-26
+
+### Changes
+
+- Sync obsidian-brain v2.4.2 (8 fixes since v2.4.1):
+  - #105 cwd-gone session-id resolution
+  - #101+#86+#110 source-session basename stability
+  - #93 (+8 follow-ups) vault-doctor immutable capture-time signals
+  - #81 vault-doctor duplicate session_id collision detection
+  - #50 E2E snapshot to /recall integration tests
+  - #68 vault-doctor snapshot_migration cross-midnight backlink
+  - #45 /compress rank-gap delta guard
+  - #78 /recall N=1 picker
+
 ## [3.6.0] - 2026-04-22
 
 ### Changes

--- a/plugins/obsidian-brain/.claude-plugin/plugin.json
+++ b/plugins/obsidian-brain/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/plugins/obsidian-brain/CHANGELOG.md
+++ b/plugins/obsidian-brain/CHANGELOG.md
@@ -7,6 +7,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-04-26
+
+### Added
+- E2E integration test for snapshot → summarize → /recall pipeline (`tests/test_snapshot_e2e.py`). Closes #50.
+- **`created_at:` ISO-8601 frontmatter** is now written by `error-log`,
+  `decide`, `retro`, and `compress` (new-note flow) for sub-day-precision
+  capture-time matching by vault-doctor. Net-additive — older notes continue
+  to fall back to `date:` (day precision).
+- `_first_seen_date(sid)` marker (atomic, idempotent JSON at `~/.claude/obsidian-brain/sessions/<sid>.json`) consulted by both `get_session_context()` and SessionEnd to keep insight wikilinks and on-disk filenames in lockstep ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix A)
+- `_resolve_session_note_by_hash()` shared helper with type+project filter and collision detection ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
+- `tests/test_get_session_context.py` — comprehensive coverage of markers, peek helpers, resolver, and the project-slug invariant
+
+### Fixed
+- **Issue #105:** `_get_session_id_fast()` no longer raises `FileNotFoundError`
+  when the cwd is deleted mid-session (e.g. via `gh pr merge --delete-branch`
+  from inside a worktree). Insight savers (`/retro`, `/compress`, `/decide`,
+  `/error-log`) now resolve the active session's SID via a recent-bootstrap
+  best-effort fallback instead of stamping `source_session: unknown`.
+- Source-session basename divergence between `get_session_context()` and SessionEnd that broke insight wikilinks across cross-midnight, worktree, and resumed sessions ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
+- Snapshot/session hash collision in the resolver could pick a snapshot when an insight saver intended to link to a session ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
+- `is_resumed_session` now returns True only when a session-type note for the current project (matched by `project_path` against `cwd`) exists for this session_id's hash — eliminating false positives from cross-project hash collisions and snapshot-only matches ([#86](https://github.com/abhattacherjee/obsidian-brain/issues/86), subsumed by [#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
+- **vault-doctor source-sessions silently corrupted backlinks** when a note's
+  mtime drifted past the originating session's JSONL window (any later edit
+  by `/check-items`, `/link`, `/compress`, sync clients, or another vault-doctor
+  check). The check now uses an immutable signal chain
+  (`created_at` → `date` → filename prefix → mtime) for capture-time matching,
+  and trusts an existing `source_session` whose JSONL window overlaps the
+  note's calendar day. Issue payloads surface `capture_signal` and
+  `capture_confidence` so operators can spot heuristic falls. Closes #93.
+- **vault-doctor source-sessions further hardening** (issue #93 follow-ups
+  surfaced via dev-test verification):
+  - Snapshot notes are now filtered out of the session-note SID index.
+    PreCompact snapshots inherit the parent session's UUID; without the
+    filter they could clobber the parent in the index, causing T5c's
+    basename-only repairs to propose snapshot basenames as 'correct'.
+  - Notes whose `source_session` UUID has a real JSONL but no session
+    note are no longer routed to the date-window matcher. The UUID is
+    authoritative; the missing session note is tracked separately
+    (issue #98).
+  - Day-precision signals (`date`, `filename`) now use a day-overlap
+    matcher (greatest overlap with the UTC calendar day) instead of a
+    noon-UTC point match. Morning-only and evening-only sessions are
+    no longer silently excluded from candidacy.
+- **vault-doctor source-sessions multi-session-day convergence**: when a
+  worktree-launched insight records `project: <main>` but its source
+  session has `project: <main>--<worktree-slug>`, the UUID lookup
+  previously failed and the matcher converged every flagged note onto
+  whatever session's window contained noon-UTC. Now uses cross-project
+  UUID indexing (Phase 1b looks up UUIDs across all projects, not just
+  the note's declared project), basename-only repair when UUID resolves
+  but the stored basename is stale, capped confidence (≤ 0.6) on
+  date-only signals, and convergence-guard tagging when ≥2 flags in a
+  project target the same proposed session (confidence further capped to
+  ≤ 0.4).
+- `/compress` Step 3.5 rank-gap guard no longer rejects legitimate same-topic peer matches. Replaced the 1.5× ratio test with a delta-score test (`|top.rank| - |#2.rank| > MIN_RANK_DELTA`) that scales with rank magnitude, so multi-phase PRs and iterative features no longer silently duplicate instead of prompting for an update. `MIN_RANK_DELTA` tuned empirically against `scripts/compress_rank_gap_corpus.json`; chosen value lives in `hooks/compress_guard.py`. Closes #45.
+- `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
+- `vault-doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.
+- `vault-doctor` `sessions_by_id` in both `snapshot_migration.py` and `snapshot_integrity.py` no longer silently relies on an arbitrary filesystem-order-dependent winner when two session notes share a `session_id`. Colliding sids are tracked in a `_sid_collisions` set at build time, and the four consumers (migration §3 / §4 and integrity §1 / §4) now treat those collisions as ambiguous: the §1/§3 emission paths surface unresolved `"ambiguous parent — multiple session notes share session_id=<sid>; resolve by deduping the colliding session notes in the sessions folder"` Issues, while the §4 fix-proposal loops skip proposing a confidently-wrong backlink or snapshots-list fix. Collision detection is project-blind so `--project=foo` can't silently filter out a cross-project collider and resurrect arbitrary-winner selection inside the filtered scan; emission indices remain project-filtered. `snapshot_integrity.py` also gains an empty-`session_id` pre-guard with a specific reason (parity with `snapshot_migration.py` §3). Surfaced during PR #80 review as a pre-existing weakness made consequential by the #68 fix. Closes #81.
+- **Project-name divergence across worktrees**: session notes and insights
+  written from a worktree previously recorded the worktree's basename as
+  their `project:` field (e.g., `obsidian-brain--issue-81-...`), causing
+  vault-doctor's source-sessions check to mis-resolve UUID lookups when
+  the same insight referenced a session run in a different worktree.
+  All vault notes now record the canonical main-repo basename (e.g.,
+  `obsidian-brain`), derived via `git rev-parse --git-common-dir`. CC's
+  internal path-encoded JSONL/bootstrap lookups are unaffected. Existing
+  notes with worktree-derived project names continue to work via the
+  UUID-first cross-project fallback in source-sessions.
+- **PR #97 reviewer findings (issue #93)**: 8 follow-up fixes applied:
+  C1+I6 surface `convergence_warning` and `convergence_count` at the
+  top level of the JSON payload (not under `extra.*`) and document the
+  `[CONVERGED <N> flags]` rendering in vault-doctor SKILL.md;
+  C2 cap `mtime`-signal proposed confidence at 0.3 (below the 0.4
+  convergence floor) so an mtime-only proposal is never auto-applied;
+  C3 emit an unresolved diagnostic Issue (with `missing_session_note`
+  and `jsonl_path`) when the source UUID has a real JSONL but no vault
+  session note, instead of silently skipping; C4 `canonical_project_name`
+  returns `"unknown"` when `os.getcwd()` raises (deleted-cwd safety so
+  hooks honor their must-exit-0 contract); C5 log a stderr warning when
+  `_list_all_session_notes` skips a `.md` file with malformed
+  frontmatter (parity with `_list_session_notes`); I4 Phase 1b now falls
+  back to `_find_jsonl_anywhere` when `_jsonl_dir_for_project` misses
+  on worktree-suffixed project names, preventing date-matcher false
+  positives; I7 tighten the UUID-trust regression test to assert the
+  C3 unresolved-Issue contract unconditionally.
+
 ## [2.4.1] - 2026-04-22
 
 ### Fixed

--- a/plugins/obsidian-brain/hooks/compress_guard.py
+++ b/plugins/obsidian-brain/hooks/compress_guard.py
@@ -1,0 +1,45 @@
+"""Pure predicate for the /compress Step 3.5 high-confidence match filter.
+
+Kept in its own module so the tuning harness (scripts/tune_compress_rank_gap.py)
+and pytest (tests/test_compress_rank_gap.py) can import it directly rather
+than shelling out through the SKILL.md embedded block.
+
+MIN_RANK_DELTA is empirically tuned against scripts/compress_rank_gap_corpus.json.
+Hard constraint: must be < 4.75 so the issue #45 repro case (top -29.46,
+runner-up -24.71) resolves to match: True. The full tuning protocol lives
+in the external spec-docs repository at
+superpowers/specs/2026-04-23-compress-rank-gap-delta-guard-design.md
+(github.com/abhattacherjee/spec-docs).
+"""
+
+MIN_RANK_STRENGTH = -5.0  # top result's FTS5 rank must be <= this (stronger = more negative)
+MIN_RANK_DELTA = 0.25     # tuned against scripts/compress_rank_gap_corpus.json on 2026-04-23
+
+
+def is_high_confidence_match(results, min_strength=None, min_delta=None):
+    """Return True if the top search result is a high-confidence match.
+
+    Arguments:
+        results: list of dicts with a "rank" field. Callers must pass the
+            list sorted most-negative first (as SKILL.md Step 3.5 does).
+        min_strength: optional override for MIN_RANK_STRENGTH.
+        min_delta: optional override for MIN_RANK_DELTA.
+
+    Returns:
+        bool. True only if (a) results is non-empty, (b) top.rank passes
+        the absolute-strength gate, and (c) either there is no runner-up
+        or the |top.rank| - |runner_up.rank| gap exceeds the delta gate.
+    """
+    if min_strength is None:
+        min_strength = MIN_RANK_STRENGTH
+    if min_delta is None:
+        min_delta = MIN_RANK_DELTA
+
+    if not results:
+        return False
+    top = results[0]
+    if top["rank"] > min_strength:
+        return False
+    if len(results) < 2:
+        return True
+    return (abs(top["rank"]) - abs(results[1]["rank"])) > min_delta

--- a/plugins/obsidian-brain/hooks/obsidian_session_hint.py
+++ b/plugins/obsidian-brain/hooks/obsidian_session_hint.py
@@ -117,6 +117,9 @@ def _run() -> None:
     cwd = hook_input.get("cwd", os.getcwd())
 
     # 2. Derive project name (needed for bootstrap before vault config).
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = get_project_name(cwd)
 
     # 2a. Refresh the bootstrap file with the authoritative session_id from stdin.

--- a/plugins/obsidian-brain/hooks/obsidian_session_log.py
+++ b/plugins/obsidian-brain/hooks/obsidian_session_log.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import obsidian_utils  # noqa: E402  — used for _first_seen_date qualified call
 from obsidian_utils import (  # noqa: E402
     build_raw_fallback,
     extract_assistant_messages,
@@ -256,12 +257,18 @@ def _run() -> None:
             )
 
         # 7. Detect resumed session
-        resumed = is_resumed_session(vault_path, sessions_folder, session_id)
+        # Pass the authoritative cwd from hook_input so the project_path filter
+        # uses Claude Code's truth-of-record rather than os.getcwd(), which can
+        # drift if anything chdir'd inside the hook process.
+        resumed = is_resumed_session(vault_path, sessions_folder, session_id, cwd=cwd)
         if resumed:
             print(f"[obsidian-brain] resumed session detected", file=sys.stderr)
 
         # 8. Build filename
-        date_str = datetime.date.today().isoformat()
+        # Use _first_seen_date so insights saved during the session and the
+        # session note written here resolve to the same basename even when
+        # the session crosses midnight or is resumed across calendar days.
+        date_str = obsidian_utils._first_seen_date(session_id)
         project_slug = slugify(metadata.get("project", "session"))
         filename = make_filename(date_str, project_slug, session_id)
 

--- a/plugins/obsidian-brain/hooks/obsidian_utils.py
+++ b/plugins/obsidian-brain/hooks/obsidian_utils.py
@@ -50,6 +50,314 @@ _RE_RAW_CONVERSATION = re.compile(
     r"^## Conversation \(raw\)\n(.+?)(?=\n^## |\Z)", re.MULTILINE | re.DOTALL
 )
 
+# Session IDs are CC UUIDs (or test fixtures). Restrict to safe filename chars
+# so the marker path never escapes ~/.claude/obsidian-brain/sessions/.
+_SID_FILENAME_SAFE = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
+
+
+def _first_seen_date(sid: str) -> str:
+    """Return the canonical first-seen calendar date for a session_id.
+
+    Atomic, idempotent, lazy: marker is written on first call and read
+    verbatim on subsequent calls — every subsequent call (across days,
+    worktrees, processes) returns the same date. If the marker becomes
+    corrupt or unreadable (e.g., truncated by an external process), the
+    function self-heals by rewriting it with today's date — note that
+    this resets the lockstep guarantee for that session_id.
+
+    Silent-failure paths (all log to stderr): unsafe sid shape, mkdir
+    failure, marker write failure — fall back to today's date and lockstep
+    is voided for that call. Used by get_session_context() and SessionEnd
+    so that source_session_note wikilinks and on-disk filenames stay in
+    lockstep even when sessions cross midnight.
+
+    Marker location: ~/.claude/obsidian-brain/sessions/<sid>.json (0o600).
+    """
+    if not _SID_FILENAME_SAFE.fullmatch(sid):
+        print(
+            f"[obsidian-brain] _first_seen_date: refusing unsafe sid shape; "
+            f"falling back to today's date",
+            file=sys.stderr,
+        )
+        return datetime.date.today().isoformat()
+
+    marker_dir = Path.home() / ".claude" / "obsidian-brain" / "sessions"
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if marker_dir.stat().st_mode & 0o077:
+            os.chmod(marker_dir, 0o700)
+    except OSError as exc:
+        print(f"[obsidian-brain] _first_seen_date: cannot create marker dir: {exc}",
+              file=sys.stderr)
+        return datetime.date.today().isoformat()  # graceful fallback
+
+    marker = marker_dir / f"{sid}.json"
+    try:
+        date = json.loads(marker.read_text(encoding="utf-8"))["first_seen_date"]
+        # Self-heal mode if a previous bug or manual edit left it permissive.
+        try:
+            if marker.stat().st_mode & 0o077:
+                os.chmod(marker, 0o600)
+        except OSError:
+            pass  # mode-tightening is best-effort; readback already succeeded
+        return date
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError):
+        pass  # fall through and (re)write
+
+    today = datetime.date.today().isoformat()
+    payload = {
+        "first_seen_date": today,
+        "first_seen_iso": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=f".{sid}.", suffix=".json.tmp", dir=str(marker_dir)
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, marker)  # atomic on POSIX
+        tmp_path = None  # rename succeeded; nothing to clean up
+    except OSError as exc:
+        print(f"[obsidian-brain] _first_seen_date: marker write failed: {exc}",
+              file=sys.stderr)
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError as cleanup_exc:
+                print(
+                    f"[obsidian-brain] _first_seen_date: failed to clean up temp file "
+                    f"{tmp_path}: {cleanup_exc}",
+                    file=sys.stderr,
+                )
+    return today
+
+
+def _peek_frontmatter_field(path: Path, field: str) -> str | None:
+    """Return the unquoted YAML scalar for ``field:`` from a vault note's
+    frontmatter, or None. Reads at most 30 lines to keep the cost negligible
+    even when called on hash-collision (which is rare).
+
+    Stops at the closing ``---`` marker. Quote-stripping handles the common
+    cases ``"value"`` and ``'value'``; unquoted scalars are returned verbatim.
+    Empty values (``field:`` with no scalar) are normalized to None for clean
+    truthy-checks at call sites.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            in_frontmatter = False
+            for i, line in enumerate(fh):
+                if i >= 30:
+                    break
+                stripped = line.strip()
+                if stripped == "---":
+                    if not in_frontmatter:
+                        in_frontmatter = True
+                        continue
+                    break  # closing marker
+                if not in_frontmatter:
+                    continue
+                if stripped.startswith(f"{field}:"):
+                    value = stripped[len(field) + 1:].strip()
+                    if (value.startswith('"') and value.endswith('"')) or \
+                       (value.startswith("'") and value.endswith("'")):
+                        value = value[1:-1]
+                    if not value:
+                        print(
+                            f"[obsidian-brain] _peek_frontmatter_field: {path.name} has empty "
+                            f"{field!r} field — possible mid-write or corruption",
+                            file=sys.stderr,
+                        )
+                        return None
+                    return value
+    except (OSError, UnicodeDecodeError) as exc:
+        print(
+            f"[obsidian-brain] _peek_frontmatter_field: cannot read {path.name} "
+            f"for field={field!r}: {exc}; this file will be excluded from filtering",
+            file=sys.stderr,
+        )
+        return None
+    return None
+
+
+def _peek_frontmatter_type(path: Path) -> str | None:
+    return _peek_frontmatter_field(path, "type")
+
+
+def _peek_frontmatter_project_path(path: Path) -> str | None:
+    return _peek_frontmatter_field(path, "project_path")
+
+
+def _resolve_session_note_by_hash(
+    sessions_dir: Path | str,
+    h: str,
+    cwd: str | None = None,
+) -> tuple[str | None, list[str]]:
+    """Resolve ``*-{h}.md`` to a session-type note matching this project.
+
+    Replaces first-match-wins glob discipline with a type+project filter
+    that handles the three known collision modes:
+      1. session_id sharing with snapshot notes (#101 Fix C)
+      2. cross-project 4-char hash collision (#101 Fix C)
+      3. genuine same-session_id duplicates (subsumes #86)
+
+    Returns ``(basename_without_ext, collisions)``:
+      - basename_without_ext: file stem (no ``.md``) when resolved
+      - collisions: list of full filenames *with* ``.md`` so stderr
+        warnings are unambiguous when shown to the operator
+
+      - exactly one session-type match              → (basename, [])
+      - 2+ session matches but exactly one cwd match → (basename, [other names])
+      - 0 session-type matches                       → (None, [])
+      - 2+ matches and ambiguous after cwd filter    → (None, [all session names])
+
+    Caller pattern: warn on non-empty ``collisions`` and fall back to a
+    composed name (via ``make_filename(_first_seen_date(sid), project, sid)``)
+    when ``basename is None``.
+    """
+    sessions_dir = Path(sessions_dir)
+    if not sessions_dir.is_dir():
+        print(
+            f"[obsidian-brain] _resolve_session_note_by_hash: sessions_dir "
+            f"{sessions_dir} does not exist or is not readable; treating as no-match",
+            file=sys.stderr,
+        )
+        return None, []
+
+    try:
+        matches = sorted(sessions_dir.glob(f"*-{h}.md"))
+    except OSError as exc:
+        # Permission errors / transient I/O on the sessions dir must not crash
+        # SessionEnd. Fall back to (None, []) so callers compose a fresh name.
+        print(
+            f"[obsidian-brain] _resolve_session_note_by_hash: glob failed on "
+            f"{sessions_dir}: {exc}",
+            file=sys.stderr,
+        )
+        return None, []
+    # Treat type=None as claude-session for backward-compat with legacy notes
+    # that pre-date the explicit type frontmatter field — matches the same
+    # convention used by collect_open_items() in hooks/open_item_dedup.py.
+    session_matches = [m for m in matches
+                       if (_peek_frontmatter_type(m) or "claude-session") == "claude-session"]
+    if not session_matches:
+        return None, []
+
+    # Apply cwd filter when provided — covers single-match cross-project collision
+    if cwd:
+        cwd_matches = [m for m in session_matches
+                       if _peek_frontmatter_project_path(m) == cwd]
+        if len(cwd_matches) == 1:
+            others = [m.name for m in session_matches if m != cwd_matches[0]]
+            return cwd_matches[0].stem, others
+        if len(cwd_matches) == 0:
+            # No cwd match — surface ALL the cross-project matches as collisions
+            # so caller can warn, then fall back to composed name.
+            return None, [m.name for m in session_matches]
+        # Multiple cwd matches — fall through to ambiguous return below
+
+    # No cwd OR multiple cwd matches — leniently return single-match basename
+    if len(session_matches) == 1:
+        return session_matches[0].stem, []
+    return None, [m.name for m in session_matches]
+
+
+def _safe_getcwd() -> str:
+    """Return os.getcwd() or empty string if cwd is deleted/unmounted.
+
+    Hook paths must not crash on cwd-gone (issue #105 territory) — callers
+    that pass this to _resolve_session_note_by_hash get the (None, []) /
+    (None, [...]) lenient fallback when cwd resolution fails.
+    """
+    try:
+        return os.getcwd()
+    except (OSError, FileNotFoundError):
+        return ""
+
+
+def _resolve_project_basename() -> str | None:
+    """Project basename for CC-path lookups (~/.claude/projects/, sid-* bootstraps).
+
+    Resolution order:
+      1. os.getcwd() — normal case
+      2. CLAUDE_PROJECT_DIR env var — when cwd is gone (worktree deleted
+         mid-session via `gh pr merge --delete-branch`); see issue #105
+      3. None — caller should treat as 'cannot determine project' and
+         fall through to project-agnostic fallbacks
+
+    Never raises. Preserves a lazy fallback order: consult CLAUDE_PROJECT_DIR
+    only after cwd resolution fails.
+
+    Falsy basenames (empty string from cwd='/' or env var with trailing slash)
+    are normalized to None so callers fall through to safer fallback layers
+    instead of triggering an unscoped cross-project glob (which would
+    silently mis-attribute the active session).
+    """
+    try:
+        cwd_base = os.path.basename(os.getcwd())
+        return cwd_base if cwd_base else None
+    except OSError:
+        env = os.environ.get("CLAUDE_PROJECT_DIR")
+        if not env:
+            return None
+        env_base = os.path.basename(env.rstrip("/"))
+        return env_base if env_base else None
+
+
+def _recent_bootstrap_sid(window_seconds: int = 600) -> str | None:
+    """Final-fallback session-id resolver for issue #105 (cwd-gone scenario).
+
+    Scans ~/.claude/obsidian-brain/sid-* for files with mtime within the recency
+    window (default 10 min — covers any normal SessionStart-to-/retro interaction
+    window). Returns the SID iff exactly ONE recent file is found. Strict by
+    design: zero or 2+ matches return None to prevent silent mis-attribution
+    across projects (the same bug class as issue #101).
+
+    NOTE: bootstrap files are written exactly once by SessionStart and immutable
+    thereafter — so mtime IS capture time for them. This is the opposite of the
+    `technical_mtime_not_capture_time` warning, which applies to vault notes
+    edited by /check-items, /link, etc.
+
+    Reads the bootstrap dir via os.path.expanduser at call time (not the
+    module-level _SECURE_DIR constant) so HOME-redirecting test fixtures work.
+    """
+    import time
+    bdir = os.path.expanduser("~/.claude/obsidian-brain")
+    cutoff = time.time() - window_seconds
+    try:
+        entries = os.listdir(bdir)
+    except OSError:
+        return None
+
+    candidates: list[str] = []
+    for name in entries:
+        if not name.startswith("sid-") or name.endswith(".tmp"):
+            continue
+        path = os.path.join(bdir, name)
+        if _safe_mtime(path) < cutoff:
+            continue
+        try:
+            with open(path, "r") as f:
+                content = f.read().strip()
+        except OSError:
+            continue
+        if not content:
+            continue
+        # Validate SID format before trusting the file content. Without this,
+        # a corrupted or attacker-controlled bootstrap file could propagate
+        # path-traversal-style strings (e.g., "../foo") into cache_get/cache_set
+        # path composition. _SID_FILENAME_SAFE is [A-Za-z0-9._-]{1,128}.
+        if not _SID_FILENAME_SAFE.fullmatch(content):
+            continue
+        candidates.append(content)
+        if len(candidates) > 1:
+            return None  # short-circuit — strict exactly-one
+
+    return candidates[0] if len(candidates) == 1 else None
+
+
 # --- Secure working directory ---
 # All temp/cache files use ~/.claude/obsidian-brain/ (0o700) instead of /tmp.
 # This prevents symlink attacks and cache poisoning on multi-user systems.
@@ -91,6 +399,106 @@ def _safe_mtime(path: str) -> float:
         return -1.0
 
 
+# Module-level flag for SF7 one-shot warning. Avoids spamming stderr on every
+# canonical_project_name() call when git is unavailable for the whole process.
+_git_fallback_warned: bool = False
+
+
+def _git_canonical_project_name_with_reason(
+    cwd: str | None = None,
+) -> tuple[str | None, str]:
+    """Return (canonical_name_or_None, reason).
+
+    reason is one of:
+      - "ok" — name resolved successfully
+      - "not-a-repo" — git ran but cwd is not inside a git work-tree (returncode != 0).
+        This is a NORMAL operating condition; callers should NOT warn.
+      - "git-unavailable" — git binary missing or subprocess raised OSError.
+        Genuine error; callers SHOULD warn.
+      - "empty-output" — git ran clean but returned no path. Should not happen.
+      - "resolve-failed" — relative-path resolve raised OSError.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd or None,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (None, "git-unavailable")
+    if result.returncode != 0:
+        return (None, "not-a-repo")
+    common_dir = result.stdout.strip()
+    if not common_dir:
+        return (None, "empty-output")
+    common_dir_path = Path(common_dir)
+    if not common_dir_path.is_absolute():
+        base = Path(cwd) if cwd else Path.cwd()
+        try:
+            common_dir_path = (base / common_dir).resolve()
+        except OSError:
+            return (None, "resolve-failed")
+    name = common_dir_path.parent.name
+    if not name:
+        return (None, "empty-output")
+    return (name, "ok")
+
+
+def _git_canonical_project_name(cwd: str | None = None) -> str | None:
+    """Return the main-repo basename via `git rev-parse --git-common-dir`.
+
+    For a worktree, `--git-common-dir` returns the path to the SHARED .git
+    of the main repo (e.g., `/path/main-repo/.git`). The parent's basename
+    is the canonical project name across all worktrees.
+
+    Returns None if not in a git repository or git is unavailable. Caller
+    should fall back to cwd basename in that case.
+    """
+    name, _reason = _git_canonical_project_name_with_reason(cwd)
+    return name
+
+
+def canonical_project_name(cwd: str | None = None) -> str:
+    """Return the canonical (main-repo) project name for cwd.
+
+    Worktrees of the same repo all return the same canonical name. This
+    is what should be written to vault-note frontmatter `project:` fields
+    so cross-worktree work groups under one logical project.
+
+    Falls back to cwd basename if not in a git repo. Returns 'unknown' when
+    the working directory cannot be determined (e.g., the directory was
+    deleted mid-session via `gh pr merge --delete-branch`); hooks must exit
+    0, so raising would violate the contract. Result is lowercased and
+    underscores/spaces normalized to hyphens.
+
+    Emits a one-shot stderr warning per process ONLY when git is genuinely
+    unavailable or errors out (binary missing, empty output, resolve failure).
+    Does NOT warn for the normal "cwd is not in a git repo" case — that's a
+    common, expected operating condition and warning would be noise (review
+    Copilot R2).
+    """
+    name, reason = _git_canonical_project_name_with_reason(cwd)
+    if name is None:
+        if reason in ("git-unavailable", "empty-output", "resolve-failed"):
+            global _git_fallback_warned
+            if not _git_fallback_warned:
+                _git_fallback_warned = True
+                print(
+                    f"[obsidian_utils] canonical_project_name: git error "
+                    f"({reason}), using cwd basename — verify project: "
+                    f"frontmatter writes",
+                    file=sys.stderr,
+                )
+        try:
+            base = cwd if cwd else os.getcwd()
+        except (OSError, FileNotFoundError):
+            return "unknown"
+        name = os.path.basename(base)
+    return name.lower().replace(" ", "-").replace("_", "-")
+
+
 def _glob_project_jsonls(safe_project: str, suffix: str = "*.jsonl") -> list[str]:
     """Glob ~/.claude/projects/*<project>/<suffix>, with underscore-to-hyphen fallback.
 
@@ -109,15 +517,15 @@ def _glob_project_jsonls(safe_project: str, suffix: str = "*.jsonl") -> list[str
     return matches
 
 
-def _slow_path_newest_sid() -> str:
-    """Determine the current session id by scanning JSONL files directly.
+def _try_slow_jsonl_glob(project: str) -> str:
+    """Slow path: glob all JSONLs under ~/.claude/projects/*<project>/, return
+    SID of the newest. Used by both _resolve_session_id (when bootstrap is
+    skipped or empty) and as the existing health-check entry point.
 
-    Bootstrap-independent — does NOT read, write, or trust the bootstrap
-    cache. Used by health checks that must not be fooled by stale cache
-    entries. Returns 'unknown' if no JSONLs are found for the current cwd.
+    Returns 'unknown' if no JSONLs match. Bootstrap-blind by contract — never
+    reads or trusts the sid-<project> bootstrap file.
     """
     import glob as _glob
-    project = os.path.basename(os.getcwd())
     safe_project = _glob.escape(project)
     matches = _glob_project_jsonls(safe_project)
     entries = [(_safe_mtime(p), p) for p in matches]
@@ -128,8 +536,22 @@ def _slow_path_newest_sid() -> str:
     return os.path.splitext(os.path.basename(newest))[0]
 
 
-def _get_session_id_fast() -> str:
-    """Derive session ID, using bootstrap file for speed on repeat calls.
+def _slow_path_newest_sid() -> str:
+    """Determine the current session id by scanning JSONL files directly.
+
+    Bootstrap-independent — does NOT read, write, or trust ANY bootstrap
+    file (neither the per-project sid-<project> cache nor the cross-project
+    recent-bootstrap directory scan). Used by health checks (e.g.,
+    check_hook_status) that must not be fooled by stale bootstraps.
+
+    Returns 'unknown' if no JSONLs are found for the current cwd.
+    """
+    return _resolve_session_id(allow_bootstrap=False)
+
+
+def _try_bootstrap_fast_path(project: str) -> str | None:
+    """Bootstrap fast path: read sid-<project>, validate against JSONL existence
+    and newest-mtime tiebreaker. Returns cached SID on hit, None on miss/stale.
 
     Validation strategy:
       1. Read bootstrap file (~0.1 ms)
@@ -139,97 +561,97 @@ def _get_session_id_fast() -> str:
          reproducible on filesystems with 1-second mtime resolution.
       4. If the newest JSONL's basename equals the cached sid, trust the
          cache. If the cached JSONL shares the newest mtime (same-second
-         race), also trust the cache — the SessionStart hook has already
-         authoritatively written the current sid and same-mtime ties
-         effectively mean "these happened simultaneously."
-      5. Otherwise fall through to the slow path (full glob + deterministic
-         max) which is the authoritative answer.
+         race), also trust the cache.
+      5. Otherwise return None (let caller fall through to slow path).
 
-    Comparing basenames rather than mtime values directly is important
-    because the active session's JSONL is appended throughout the session,
-    so its mtime increases continuously. A naive mtime comparison would
-    invalidate the bootstrap on every call after a few seconds, defeating
-    the optimization.
-
-    The slow path is strictly READ-ONLY — it never writes the bootstrap
-    file. The SessionStart hook is the sole authoritative writer of the
-    bootstrap. Writing from the slow path would clobber the hook's correct
-    write if the slow path ran during the hook's own invocation (which
-    happens whenever downstream hook code calls a function that triggers
-    this, before CC has flushed the new session's JSONL to disk).
+    READ-ONLY — never writes the bootstrap file. SessionStart hook is the sole
+    authoritative writer.
     """
     import glob as _glob
-    project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
     safe_project = _glob.escape(project)
 
-    # Fast path: bootstrap file
     try:
         with open(bootstrap, 'r') as f:
             cached_sid = f.read().strip()
-        if cached_sid:
-            safe_cached = _glob.escape(cached_sid)
-            cached_matches = _glob_project_jsonls(
-                safe_project, f"{safe_cached}.jsonl"
-            )
-            if cached_matches:
-                # Determine the newest JSONL deterministically: order by
-                # (mtime, path). Ties broken by path string so results are
-                # reproducible across filesystems that report 1-second mtime
-                # resolution.
-                all_matches = _glob_project_jsonls(safe_project)
-                if all_matches:
-                    # Determine the newest JSONL deterministically via (mtime, path).
-                    # _safe_mtime returns -1.0 for files that disappear between glob
-                    # and stat, so transient races never crash the caller.
-                    entries = [(_safe_mtime(p), p) for p in all_matches]
-                    viable = [(m, p) for m, p in entries if m >= 0]
-                    if viable:
-                        newest_mtime, newest_path = max(viable)
-                        newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
-                        if newest_sid == cached_sid:
-                            return cached_sid
-                        # Tie-breaker: if ANY cached JSONL matches the newest
-                        # mtime (across all worktree/project-dir matches), trust
-                        # the cache. When multiple project-dir variants exist
-                        # (e.g. worktrees), the cached sid's JSONL may appear in
-                        # several of them; comparing only cached_matches[0]
-                        # could miss the tie and cause an unnecessary
-                        # fall-through. This handles the same-second race where
-                        # the previous session's JSONL and the current
-                        # session's JSONL report identical mtimes on
-                        # coarse-resolution filesystems, and the SessionStart
-                        # hook has already authoritatively written the current
-                        # sid.
-                        cached_mtimes = [_safe_mtime(p) for p in cached_matches]
-                        cached_newest = max(
-                            (m for m in cached_mtimes if m >= 0), default=-1.0
-                        )
-                        if cached_newest == newest_mtime:
-                            return cached_sid
-                        # Otherwise a different session is strictly newer; fall through.
-                    else:
-                        return cached_sid  # no viable JSONLs; trust cache
-                else:
-                    return cached_sid  # no other JSONLs; trust cache
     except OSError:
-        pass
+        return None
+    if not cached_sid:
+        return None
+    # Validate SID format before trusting the bootstrap file content. Without
+    # this, a corrupted or attacker-controlled sid-<project> file with content
+    # like "../../../tmp/foo" could propagate path-traversal strings into
+    # cache_get/cache_set composition. Mirrors the validation in
+    # _recent_bootstrap_sid() and _first_seen_date().
+    if not _SID_FILENAME_SAFE.fullmatch(cached_sid):
+        return None
 
-    # Slow path: full glob + mtime sort with deterministic tiebreaker.
-    # This path is READ-ONLY — never writes the bootstrap file. The
-    # SessionStart hook is the sole authoritative writer. Writing here
-    # would clobber the hook's correct write if the slow path ran
-    # during the hook's own invocation (which happens whenever the
-    # hook's downstream code calls a function that triggers this).
-    # Use _safe_mtime so a JSONL deleted or rotated between glob and
-    # stat cannot crash the caller (e.g. load_config).
-    matches = _glob_project_jsonls(safe_project)
-    entries = [(_safe_mtime(p), p) for p in matches]
+    safe_cached = _glob.escape(cached_sid)
+    cached_matches = _glob_project_jsonls(safe_project, f"{safe_cached}.jsonl")
+    if not cached_matches:
+        return None
+
+    all_matches = _glob_project_jsonls(safe_project)
+    if not all_matches:
+        return cached_sid  # no other JSONLs; trust cache
+
+    entries = [(_safe_mtime(p), p) for p in all_matches]
     viable = [(m, p) for m, p in entries if m >= 0]
     if not viable:
-        return "unknown"
-    _, newest = max(viable)
-    return os.path.splitext(os.path.basename(newest))[0]
+        return cached_sid  # no viable JSONLs; trust cache
+
+    newest_mtime, newest_path = max(viable)
+    newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
+    if newest_sid == cached_sid:
+        return cached_sid
+
+    # Tie-breaker: same-second race across worktrees → trust cache
+    cached_mtimes = [_safe_mtime(p) for p in cached_matches]
+    cached_newest = max((m for m in cached_mtimes if m >= 0), default=-1.0)
+    if cached_newest == newest_mtime:
+        return cached_sid
+
+    return None  # different session is strictly newer — fall through
+
+
+def _resolve_session_id(allow_bootstrap: bool = True) -> str:
+    """Single source of truth for current-session SID resolution. Never raises.
+
+    Resolution layers (each failure → next):
+      1. Project basename via _resolve_project_basename (cwd → env → None)
+      2. Bootstrap fast path (skipped if allow_bootstrap=False)
+      3. Slow-path JSONL glob
+      4. Recent-bootstrap best-effort scan (skipped if allow_bootstrap=False)
+         — issue #105 fallback for cwd-gone
+      5. 'unknown' sentinel
+
+    The `allow_bootstrap` flag gates BOTH bootstrap-reading layers (2 and 4),
+    so callers that need a bootstrap-blind result (e.g., health checks via
+    _slow_path_newest_sid) get a JSONL-only resolution.
+    """
+    project = _resolve_project_basename()
+    if project is not None:
+        if allow_bootstrap:
+            sid = _try_bootstrap_fast_path(project)
+            if sid:
+                return sid
+        sid = _try_slow_jsonl_glob(project)
+        if sid != "unknown":
+            return sid
+    if allow_bootstrap:
+        sid = _recent_bootstrap_sid()
+        if sid:
+            return sid
+    return "unknown"
+
+
+def _get_session_id_fast() -> str:
+    """Derive session ID, using bootstrap file for speed on repeat calls.
+
+    See _try_bootstrap_fast_path for the validation strategy and
+    _resolve_session_id for the full layered fallback chain (issue #105).
+    """
+    return _resolve_session_id(allow_bootstrap=True)
 
 
 def cache_get(session_id: str, key: str):
@@ -418,6 +840,9 @@ def check_hook_status() -> dict:
     "ok" is False only when the bootstrap file is missing entirely or no
     session files can be found.
     """
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
 
@@ -473,7 +898,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     """Get session ID, hash, project, and session note name. Cached.
 
     Returns {session_id, hash, project, session_note_name} or
-    {session_id: 'unknown', hash: '', project: <cwd basename>, session_note_name: ''}.
+    {session_id: 'unknown', hash: '', project: <canonical-project>, session_note_name: ''}.
     """
     sid = _get_session_id_fast()
     # Include args in cache key so different call signatures don't collide
@@ -482,7 +907,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     if cached is not None:
         return cached
 
-    project = os.path.basename(os.getcwd()).lower().replace(' ', '-').replace('_', '-')
+    project = canonical_project_name()
     if sid == "unknown":
         # Don't cache "unknown" — would pollute cache shared across projects
         return {"session_id": "unknown", "hash": "", "project": project, "session_note_name": ""}
@@ -491,17 +916,33 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
 
     session_note_name = ""
     if vault_path and sessions_folder:
-        sessions_dir = os.path.join(vault_path, sessions_folder)
-        if os.path.isdir(sessions_dir):
-            for fname in os.listdir(sessions_dir):
-                if fname.endswith(f'-{h}.md'):
-                    session_note_name = fname[:-3]  # strip .md
-                    break
+        sessions_dir = Path(vault_path) / sessions_folder
+        resolved, collisions = _resolve_session_note_by_hash(
+            sessions_dir, h, cwd=_safe_getcwd()
+        )
+        # WARN fires once per (session, vault, folder) — cache_set below
+        # persists the result to ~/.claude/obsidian-brain/cache-<sid>.json,
+        # suppressing repeats across this hook process and any subsequent
+        # skill invocations within the same session until SessionEnd cleans
+        # up the cache. Don't spam stderr.
+        if collisions:
+            print(
+                f"[obsidian-brain] WARN: hash {h} matches {len(collisions) + (1 if resolved else 0)} "
+                f"session note(s); chose {resolved or '<none — fell back to composed name>'} "
+                f"(others: {collisions})",
+                file=sys.stderr,
+            )
+        if resolved:
+            session_note_name = resolved
 
-    # If not found, construct expected name
+    # If not found, compose the canonical basename. Both _first_seen_date()
+    # and make_filename() are also called by SessionEnd, so insight wikilinks
+    # and session-note filenames stay in lockstep across cross-midnight,
+    # worktree, and resumed-session conditions. (#101 Fix A + Fix B.)
     if not session_note_name:
-        from datetime import date
-        session_note_name = f"{date.today().isoformat()}-{project}-{h}"
+        session_note_name = make_filename(
+            _first_seen_date(sid), slugify(project), sid
+        )[:-3]
 
     ctx = {"session_id": sid, "hash": h, "project": project, "session_note_name": session_note_name}
     cache_set(sid, cache_key, ctx)
@@ -960,7 +1401,7 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
     errors, duration_minutes, commits.
     """
     meta: dict = {
-        "project": Path(cwd).name.lower().replace(" ", "-").replace("_", "-") if cwd else "unknown",
+        "project": canonical_project_name(cwd) if cwd else "unknown",
         "project_path": cwd or "",
         "git_branch": "",
         "files_touched": [],
@@ -2499,7 +2940,12 @@ def extract_tool_uses(messages: list[dict]) -> list[dict]:
 
 
 def get_project_name(cwd: str) -> str:
-    """Return the basename of the working directory as the project name."""
+    """Return the basename of the working directory as the project name.
+
+    Used for CC's path-encoded bootstrap/JSONL lookups; for vault frontmatter
+    use ``canonical_project_name()`` instead so worktrees of the same repo
+    share one logical project value.
+    """
     return Path(cwd).name if cwd else "unknown"
 
 
@@ -2886,16 +3332,36 @@ def build_raw_fallback(
 
 
 def is_resumed_session(
-    vault_path: str, sessions_folder: str, session_id: str
+    vault_path: str, sessions_folder: str, session_id: str,
+    cwd: str | None = None,
 ) -> bool:
-    """Check if a note with the same session_id hash already exists in the vault."""
+    """Return True iff a session-type note matching this session_id's hash
+    exists for the current project. Snapshot-type notes are intentionally
+    ignored (#101 Fix C), and cross-project hash collisions are skipped via
+    project_path filtering. Subsumes #86.
+
+    ``cwd`` overrides ``os.getcwd()`` for the project_path filter. SessionEnd
+    callers should pass ``hook_input["cwd"]`` (the authoritative project
+    path from Claude Code) so that hook processes that have chdir'd
+    elsewhere still classify the session against the right project.
+    Falls back to ``_safe_getcwd()`` when ``cwd`` is None.
+    """
     sessions_dir = Path(vault_path) / sessions_folder
     if not sessions_dir.exists():
         return False
     h = hashlib.sha256(session_id.encode()).hexdigest()[:4]
-    for _ in sessions_dir.glob(f"*-{h}.md"):
-        return True
-    return False
+    effective_cwd = cwd if cwd is not None else _safe_getcwd()
+    resolved, collisions = _resolve_session_note_by_hash(
+        sessions_dir, h, cwd=effective_cwd
+    )
+    if collisions:
+        # Caller contract is bool-only; warn so the operator can investigate.
+        print(
+            f"[obsidian-brain] WARN: is_resumed_session: hash {h} collides "
+            f"across {len(collisions) + (1 if resolved else 0)} session note(s)",
+            file=sys.stderr,
+        )
+    return resolved is not None
 
 
 def upgrade_note_with_summary(

--- a/plugins/obsidian-brain/scripts/compress_rank_gap_corpus.json
+++ b/plugins/obsidian-brain/scripts/compress_rank_gap_corpus.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "created": "2026-04-23",
+  "description": "Tuning corpus for /compress Step 3.5 rank-gap guard (issue #45). Seeded with the original repro case and a wide-gap synthetic; expanded by scripts/tune_compress_rank_gap.py consumers and via replay mining (see spec tuning protocol).",
+  "queries": [
+    {
+      "id": "replay-pr43-snapshot",
+      "query": "PR 43 snapshot dev-test smoke results",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Original issue #45 repro case — top -29.46, runner-up -24.71, delta 4.75. Threshold >= 4.75 fails to fix the bug."
+    },
+    {
+      "id": "synthetic-single-strong",
+      "query": "snapshot summary integration PR 43",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Narrow query with a single strong match. Serves as sanity check that the strength gate alone (no runner-up) still admits obvious matches."
+    },
+    {
+      "id": "replay-compress-rank-gap-false-negative",
+      "query": "compress rank gap false negative same topic peers",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays the /compress invocation that surfaced the issue #45 bug. Vault has exactly one dedicated insight note on this topic (2026-04-18-compress-rank-gap-rejects-same-topic-peers-0cef.md). Wide gap expected."
+    },
+    {
+      "id": "replay-hook-simulation-precompact",
+      "query": "hook simulation pattern precompact sessionend pipe JSON",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays /compress on hook simulation pattern. One dedicated note exists (2026-04-18-hook-simulation-pattern-precompact-sessionend-from-r-1f4b.md). Unique topic with expected wide gap."
+    },
+    {
+      "id": "replay-recall-optimization-parallel-haiku",
+      "query": "recall optimization sprint parallel Haiku session performance",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays /compress on recall optimization. One primary insight note (2026-04-10-recall-optimization-sprint-243s-to-80s-67-reduct-d75c.md). Strong unique match expected."
+    },
+    {
+      "id": "replay-novel-unique-topic",
+      "query": "some novel unique topic xyz123",
+      "source": "replay",
+      "expected_match": false,
+      "note": "Extracted verbatim from a session /compress invocation. String xyz123 has zero vault matches; any FTS5 result is unrelated noise. Expected: no high-confidence match."
+    },
+    {
+      "id": "synthetic-wide-gap",
+      "query": "SessionEnd hook atomic write temp rename vault note",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Wide-gap synthetic. Targets the obsidian-brain atomic-write pattern; one dominant note covers it. Large delta expected (single strong hit)."
+    },
+    {
+      "id": "synthetic-narrow-gap-multi-match",
+      "query": "obsidian-brain security audit path containment hardening vulnerabilities",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Narrow-gap multi-match synthetic. Security hardening topic has ~14 notes; top 2 should be close in rank. Tests whether the guard correctly allows the strongest match through despite multiple nearby results."
+    },
+    {
+      "id": "synthetic-three-close-results",
+      "query": "vault search FTS5 sqlite index recall ranking score",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Three-close-results synthetic. FTS5/vault-index topic has ~43 notes; top 3 results likely cluster closely. Tests the guard at the three-peer boundary."
+    },
+    {
+      "id": "synthetic-off-topic-outrank",
+      "query": "fix the code check it",
+      "source": "synthetic",
+      "expected_match": false,
+      "note": "Off-topic outrank synthetic. Generic phrase designed to surface unrelated or low-rank results. No genuine match expected; strength gate or delta gate should reject."
+    }
+  ]
+}

--- a/plugins/obsidian-brain/scripts/dev-test/DEV-TEST-ISSUE-101.md
+++ b/plugins/obsidian-brain/scripts/dev-test/DEV-TEST-ISSUE-101.md
@@ -1,0 +1,266 @@
+# Dev-Test: Source-Session Basename Stability (Issue #101 / PR #109)
+
+This is the **live Claude Code smoke test** for the source-session basename
+stability work (closes #101 + #86 + #110). It complements the automated
+script `scripts/dev-test/test-issue-101-manual.sh` which covers everything
+that can be validated via hook simulation against a throwaway fixture vault.
+
+The phases below are the bits that **only a real CC session can hit** —
+SessionStart hook narrative, real on-disk vault, /recall round-trip,
+mid-session resume.
+
+## Prerequisites
+
+1. `feature/issue-101-source-session-basename-stability` checked out, or
+   PR #109 already merged to develop and pulled.
+2. `/dev-test install` executed — installed plugin cache now contains
+   `_first_seen_date`, `_resolve_session_note_by_hash`,
+   `_peek_frontmatter_{type,project_path}`, `_safe_getcwd`, and
+   `is_resumed_session(cwd=...)`.
+3. **A new Claude Code session started** in this repo so the installed
+   SKILL.md content is loaded (skill content is read at session start).
+4. Your real Obsidian vault is configured.
+
+Before doing the live flow, run:
+
+```bash
+bash scripts/dev-test/test-issue-101-manual.sh
+```
+
+All automated checks should pass. Only proceed to the live phases below
+once the script reports `0 failed`.
+
+---
+
+## Live smoke checklist
+
+Walk through the following in a **fresh CC session**. Check each box only
+after visually confirming the described behavior. Notes section at the
+bottom for any deviations.
+
+### Phase 1 — Baseline: marker file is lazily written on first invocation
+
+> **Design note (per spec §Fix A):** the marker is **pure-lazy**. No SessionStart
+> hook calls `_first_seen_date()` directly. The marker file is created on the
+> first invocation of the helper — typically at SessionEnd when the vault note
+> basename is composed, or earlier if a helper that uses `get_session_context()`
+> falls through to its compose fallback (e.g. via /recall, /vault-search,
+> /compress when the session note doesn't already exist in vault).
+>
+> Mid-session, **it is normal for the marker file to be absent** until something
+> triggers the helper. This is by design — the spec calls out that pre-PR
+> sessions also "get markers lazily on first helper call after upgrade."
+
+- [ ] **Capture this session's ID.** In the new CC session, run:
+      ```bash
+      ls -t ~/.claude/projects/*obsidian-brain*/*.jsonl | head -1
+      ```
+      Note the basename minus `.jsonl` — that's `$SID`.
+
+- [ ] **Force the lazy write, then verify the marker.** Trigger any helper
+      that exercises the resolver — `/recall`, `/vault-search anything`, or
+      a direct Bash call — then check:
+      ```bash
+      python3 -c '
+      import sys, glob, os
+      sys.path.insert(0, glob.glob(os.path.expanduser("~/.claude/plugins/cache/claude-code-skills/obsidian-brain/2.4.1/hooks"))[0])
+      import obsidian_utils; obsidian_utils._first_seen_date("'"$SID"'")'
+
+      ls -la ~/.claude/obsidian-brain/sessions/$SID.json
+      cat ~/.claude/obsidian-brain/sessions/$SID.json
+      ```
+      File should exist with mode `-rw-------` (0o600), and JSON should
+      contain `first_seen_date` (today, ISO) and `first_seen_iso` (UTC ISO).
+
+      *If still missing after a forced helper call:* the install didn't pick
+      up the new code, or `_first_seen_date` itself failed. Check
+      `~/.claude/obsidian-brain-hook.log` and `diff -q hooks/obsidian_utils.py
+      ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/2.4.1/hooks/obsidian_utils.py`.
+
+### Phase 2 — Marker is idempotent under live use
+
+- [ ] **Trigger any /recall, /vault-search, or /compress.** Then re-check
+      the marker:
+      ```bash
+      stat -f '%Sm' ~/.claude/obsidian-brain/sessions/$SID.json   # macOS
+      # or: stat -c '%y' ~/.claude/obsidian-brain/sessions/$SID.json   # linux
+      ```
+      Modification time should match the FIRST write — subsequent calls
+      to `_first_seen_date($SID)` must read the marker, not rewrite it.
+
+- [ ] **Marker JSON contents stable.**
+      ```bash
+      cat ~/.claude/obsidian-brain/sessions/$SID.json
+      ```
+      `first_seen_date` and `first_seen_iso` should be unchanged from
+      Phase 1. If they advanced, the helper is rewriting on every call.
+
+### Phase 3 — SessionEnd basename matches marker date
+
+- [ ] **End the session cleanly.** Either type `Ctrl-D` or `/quit`. SessionEnd
+      hook fires, writes a vault note, attempts AI summarization.
+
+- [ ] **Vault note basename starts with marker date.** From a regular shell:
+      ```bash
+      VAULT=$(jq -r .vault_path ~/.claude/obsidian-brain-config.json)
+      MARKER_DATE=$(jq -r .first_seen_date ~/.claude/obsidian-brain/sessions/$SID.json)
+      ls -t "$VAULT/claude-sessions/" | grep "$SID" | head -3
+      ```
+      The most recent file matching `*-$SID*.md` should start with
+      `$MARKER_DATE-`. If today and marker date differ (cross-midnight run),
+      the file MUST use marker date — that's the whole point of #101.
+
+- [ ] **No drift between filename and frontmatter.** Open the new note
+      in any editor:
+      ```bash
+      head -10 "$VAULT/claude-sessions/$MARKER_DATE-"*"-$SID"*.md
+      ```
+      Frontmatter `session_id` should equal `$SID` and `project_path`
+      should equal this repo's path.
+
+### Phase 4 — Resume same SID → is_resumed_session=True
+
+- [ ] **Restart in this repo with the same session ID.**
+      ```bash
+      claude --resume $SID
+      ```
+
+- [ ] **SessionStart hint reflects resume.** Look at the SessionStart
+      additionalContext output (in the conversation header or hook log).
+      It should mention "Last session for obsidian-brain" — proving
+      `is_resumed_session` returned True via the resolver, not by date
+      heuristic.
+
+      *Verify the underlying check in a Bash cell:*
+      ```bash
+      python3 -c '
+      import sys, glob, os
+      sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks"))))
+      import obsidian_utils
+      v = "/Users/abhishek/path/to/your/vault"  # edit
+      print(obsidian_utils.is_resumed_session(v, "claude-sessions", "'$SID'", cwd=os.getcwd()))
+      ' # → True
+      ```
+
+### Phase 5 — Cross-project hash collision is rejected
+
+- [ ] **Find a hash collision (or fabricate one).** Look for any other
+      project in the same vault whose session note shares the first 4
+      hex chars of the SHA-256 of your `$SID`:
+      ```bash
+      python3 -c "import hashlib; print(hashlib.sha256(b'$SID').hexdigest()[:4])"
+      ```
+      Use that 4-char `$H` to grep the vault:
+      ```bash
+      ls "$VAULT/claude-sessions/" | grep -- "-$H.md" | head
+      ```
+      If a SECOND project's note appears, you have a real collision pair.
+
+      *If no natural collision exists*, fabricate one in a temp project:
+      ```bash
+      cp "$VAULT/claude-sessions/$(ls "$VAULT/claude-sessions/" | grep -- "-$H.md" | head -1)" \
+         "$VAULT/claude-sessions/2026-04-20-fabricated-$H.md"
+      ```
+      Edit the copy's frontmatter to set `project_path: "/totally/different"`.
+
+- [ ] **is_resumed_session returns False from a different cwd.**
+      ```bash
+      cd /tmp && python3 -c '...is_resumed_session(... cwd="/tmp")'
+      ```
+      Should be `False` — cwd-strict resolver rejects the cross-project
+      collision (closes #110). If True, the cwd filter is broken.
+
+      Clean up the fabricated file when done.
+
+### Phase 6 — Snapshot+session pair (PreCompact path)
+
+- [ ] **In a fresh CC session, chat a few turns then `/compact`.**
+      PreCompact writes a snapshot note `*-{H}-snapshot-HHMMSS.md` and
+      then continues the session.
+
+- [ ] **/recall renders snapshot under its parent session.** Run `/recall`
+      in this repo. The session history table should show the parent
+      session row, with the snapshot rendered as a nested `↳ HH:MM:SS`
+      row underneath. If the snapshot appears as its own top-level row,
+      the resolver's type filter is misclassifying it as a session.
+
+### Phase 7 — Backward-compat for legacy notes (type-missing)
+
+- [ ] **Find a legacy session note that lacks the `type:` field.**
+      ```bash
+      grep -L "^type:" "$VAULT/claude-sessions/"*.md | head -5
+      ```
+      Pick one and note its `session_id` value:
+      ```bash
+      grep -m1 "^session_id:" "$VAULT/claude-sessions/<one-of-them>.md"
+      ```
+
+- [ ] **is_resumed_session still recognizes it.** Resume with that legacy
+      sid (or just check from a Python REPL) — the resolver should treat
+      `type=None` as a session (matching the `open_item_dedup` legacy
+      convention) and return True. If it returns False, the type-missing
+      back-compat is broken.
+
+### Phase 8 — Reverse: clean restart on brand-new vault
+
+- [ ] **Move the marker dir aside, clear vault sessions for this project.**
+      ```bash
+      mv ~/.claude/obsidian-brain/sessions ~/.claude/obsidian-brain/sessions.bak
+      ```
+
+- [ ] **Start a fresh CC session.** SessionStart fires.
+
+- [ ] **Marker dir was created with mode 0o700.**
+      ```bash
+      stat -f '%Mp%Lp' ~/.claude/obsidian-brain/sessions   # macOS → 40700
+      # or: stat -c '%a' ~/.claude/obsidian-brain/sessions   # linux → 700
+      ```
+
+- [ ] **Restore.**
+      ```bash
+      rm -rf ~/.claude/obsidian-brain/sessions
+      mv ~/.claude/obsidian-brain/sessions.bak ~/.claude/obsidian-brain/sessions
+      ```
+
+### Phase 9 — Cleanup + confirmation
+
+- [ ] **Run `/dev-test restore`** to put the released plugin cache back.
+- [ ] **Confirm full test suite still passes against repo HEAD.**
+      ```bash
+      python3 -m pytest -q
+      ```
+      793 passed expected (32 in `test_get_session_context.py`, 1 new
+      marker-mode self-heal test on top of the pre-#109 baseline).
+
+---
+
+## What this validates that pytest does NOT
+
+| Phase | Coverage gap pytest can't fill |
+|-------|-------------------------------|
+| 1, 2  | Lazy marker is created+stable when `_first_seen_date()` is invoked from inside a *real* running CC session against the installed cache, not by direct helper call from a unit test (per spec §Fix A: pure-lazy, no dedicated hook) |
+| 3     | SessionEnd hook integration — full write path under real config + transcript flow, including AI summarization fallback |
+| 4     | SessionStart hint render correctness — `is_resumed_session` plumbed through the user-visible "Last session" line |
+| 5     | A genuine cross-project hash collision against your live vault, not a synthetic 4-char fixture |
+| 6     | PreCompact snapshot type filter — verified through /recall's actual nested-row rendering, not just resolver unit tests |
+| 7     | Legacy notes from before the `type:` convention existed — only your live vault has these |
+| 8     | Marker dir bootstrap on first run after install — covered by chmod-self-heal unit tests but worth a real fresh start |
+
+---
+
+## Notes / deviations
+
+(Record any unexpected behavior, broken assumptions, or test-skip rationales here.)
+
+```
+- Phase X: …
+```
+
+---
+
+## Reference
+
+- Plan: `~/dev/claude_workspace/docs/superpowers/plans/2026-04-25-issue-101-source-session-basename-stability-plan.md`
+- Spec: `~/dev/claude_workspace/docs/superpowers/specs/2026-04-25-issue-101-source-session-basename-stability-design.md`
+- Closes: #101 (write-side ABC), #86 (read-side hash resolver), #110 (cross-project collision)
+- Related issues NOT closed by this PR: #102 (D, render-side defense — depends on #101), #103 (E, vault-doctor --min-confidence flag)

--- a/plugins/obsidian-brain/scripts/dev-test/DEV-TEST-ISSUE-105.md
+++ b/plugins/obsidian-brain/scripts/dev-test/DEV-TEST-ISSUE-105.md
@@ -1,0 +1,190 @@
+# DEV-TEST: Issue #105 — cwd-gone session-id resolution
+
+**Companion to:** `scripts/dev-test/test-issue-105-manual.sh`
+**Run by:** Sibling Claude Code session (NOT the one developing the fix)
+**Prereq:** `/dev-test install` has synced the feature branch
+
+This checklist exercises the parts that the fixture script can't: real CC
+harness behavior under a real `gh pr merge --delete-branch` worktree-deletion.
+The Python self-heal happens inside the SKILL's helper subprocess; live-CC
+verifies that retro/compress/decide/error-log all pick up the real SID
+instead of stamping `source_session: unknown`.
+
+---
+
+## Phase 1: Setup (baseline — confirm normal flow works)
+
+- [ ] **1a.** Open a fresh CC session in a sibling terminal (do NOT reuse the
+  development session — that would dirty the cwd-gone test).
+
+- [ ] **1b.** Create a throwaway worktree:
+
+  ```bash
+  cd ~/dev/claude_workspace/obsidian-brain
+  git worktree add /tmp/ob-105-test -b feature/test-105-cwd-gone-throwaway
+  cd /tmp/ob-105-test
+  ```
+
+- [ ] **1c.** Open a Claude Code session **inside** `/tmp/ob-105-test/` and
+  let SessionStart fire.
+
+- [ ] **1d.** Run `/compress` with any short topic (e.g. "smoke test").
+  Verify the resulting insight note in
+  `~/obsidian/claude-code-vault/claude-insights/` has a real
+  `source_session:` UUID and a non-empty `source_session_note:` basename.
+  This is the **baseline** — confirms normal flow before the wedge.
+
+  Expected: `source_session: <real-uuid>` and
+  `source_session_note: 2026-MM-DD-obsidian-brain--issue-test-...md`.
+
+---
+
+## Phase 2: Wedge the cwd
+
+- [ ] **2a.** From inside the same `/tmp/ob-105-test` CC session, push the
+  branch and create a PR (no real review required — this is throwaway):
+
+  ```bash
+  # NOTE: --allow-empty does not work — commit-preflight.sh:58 refuses
+  # commits with no staged files. Stage a tiny throwaway file instead:
+  echo "throwaway" > THROWAWAY.md
+  git add THROWAWAY.md
+  ./scripts/commit-preflight.sh --auto   # auto path = docs-only, skips tests
+  git commit -m "test: throwaway for #105 dev-test"
+  git push -u origin feature/test-105-cwd-gone-throwaway
+  gh pr create --base develop --title "DO NOT MERGE — #105 dev-test throwaway" \
+      --body "Throwaway PR for #105 dev-test. Will be closed."
+  ```
+
+- [ ] **2b.** Trigger the worktree-deletion failure mode:
+
+  ```bash
+  gh pr close --delete-branch <PR_NUMBER>
+  ```
+
+  > **Note:** On macOS gh ≥ 2.x, `gh pr close --delete-branch` automatically
+  > runs the equivalent of `git worktree remove` when the deleted branch is
+  > checked out in a worktree, AND switches the worktree to the default
+  > branch. So the explicit `git worktree remove` step below is usually
+  > unnecessary. Only run it if `git worktree list` still shows the
+  > throwaway worktree:
+  >
+  > ```bash
+  > git worktree remove --force /tmp/ob-105-test  # only if still listed
+  > ```
+
+  (Or, if your workflow uses `gh pr merge --delete-branch`, do that — the
+  worktree-deletion outcome is identical.)
+
+- [ ] **2c.** Confirm the cwd is now wedged. In the same CC session:
+
+  ```
+  Bash: pwd
+  ```
+
+  Expected: exit non-zero with "shell-init: error retrieving current directory"
+  or similar. **The CC harness's tracked cwd points at the deleted directory.**
+
+---
+
+## Phase 3: Trigger the fix path
+
+> **⏱ 10-minute window — IMPORTANT.** Layer 4 (`_recent_bootstrap_sid`) is
+> strict-by-design and only considers bootstrap files with mtime within the
+> last 600 seconds, to prevent silent cross-project mis-attribution (same
+> bug class as #101). Run Phase 3 within **10 minutes of the parent
+> SessionStart** that wrote `~/.claude/obsidian-brain/sid-<slug>`. If you
+> exceed the window, either: (a) restart the wedged CC session to write a
+> fresh bootstrap, or (b) `touch ~/.claude/obsidian-brain/sid-<slug>` just
+> before running step 3a.
+
+> **🚧 Known macOS harness blocker.** On macOS, the CC Bash tool
+> pre-checks cwd existence and refuses dispatch with `Path X does not exist`
+> the moment the cwd is gone — upstream of every SKILL bash step. This means
+> `/retro` and `/compress` cannot reach the resolver helper subprocess from
+> a wedged session at all. Verified empirically 2026-04-26 in PR #113
+> dev-test (see [[2026-04-26-test-steps-for-issue-105-cwd-gone-session-i-639d]]).
+> Tier 2 live-CC verification of Phase 3 is therefore BLOCKED on macOS until
+> the harness pre-dispatch check is relaxed (filed as follow-up). The
+> resolver fix itself is verified by `test-issue-105-manual.sh` Phase C
+> (real OS-level cwd deletion + helper invocation, 4/4 passing).
+
+- [ ] **3a.** Without leaving the wedged session, run `/retro`. Let it complete.
+
+  Pre-fix behavior: bash prelude no-ops; Python `os.getcwd()` raises;
+  helper exits non-zero; SKILL stamps `source_session: unknown`.
+
+  Post-fix behavior: bash prelude no-ops; Python falls through layers
+  1→4 and resolves the active session's SID via the recent-bootstrap
+  best-effort scan; SKILL stamps the real SID.
+
+- [ ] **3b.** Optionally run `/compress` with another short topic to confirm
+  the fix applies to all four insight-saver SKILLs.
+
+---
+
+## Phase 4: Verify
+
+- [ ] **4a.** Find the latest retro:
+
+  ```bash
+  ls -t ~/obsidian/claude-code-vault/claude-insights/*retro*.md | head -1
+  ```
+
+- [ ] **4b.** Verify `source_session` is a real UUID, NOT `unknown`:
+
+  ```bash
+  grep "^source_session" $(ls -t ~/obsidian/claude-code-vault/claude-insights/*retro*.md | head -1)
+  ```
+
+  Expected: `source_session: <8-4-4-4-12-hex-UUID>` (the real session ID).
+  **If you see `source_session: unknown`, the fix did not take effect.**
+
+  Common reasons for failure:
+  - `/dev-test install` did not pick up the latest feature branch
+    (verify with: `grep _resolve_session_id ~/.claude/plugins/cache/*/obsidian-brain/*/hooks/obsidian_utils.py`)
+  - SessionStart never wrote a bootstrap for this worktree (verify:
+    `ls -la ~/.claude/obsidian-brain/sid-ob-105-test*` — should exist
+    with mtime within last 10 minutes)
+  - More than one recent bootstrap (`ls -la ~/.claude/obsidian-brain/sid-* | grep "$(date +%H:%M)"`)
+    — Layer 4 is strict and returns "unknown" rather than guess
+
+- [ ] **4c.** Verify `source_session_note` is non-empty:
+
+  ```bash
+  grep "^source_session_note" $(ls -t ~/obsidian/claude-code-vault/claude-insights/*retro*.md | head -1)
+  ```
+
+  Expected: a non-empty `.md` filename pointing at a real session note.
+
+- [ ] **4d.** Verify the bootstrap file used:
+
+  ```bash
+  cat ~/.claude/obsidian-brain/sid-ob-105-test  # or whatever the worktree slug was
+  ```
+
+  Expected: matches the `source_session` value from 4b.
+
+---
+
+## Cleanup
+
+```bash
+gh pr close --delete-branch <PR_NUMBER>  # if not already
+git worktree remove --force /tmp/ob-105-test 2>/dev/null
+git branch -D feature/test-105-cwd-gone-throwaway
+git push origin --delete feature/test-105-cwd-gone-throwaway 2>/dev/null
+```
+
+Optional: delete the throwaway retros:
+
+```bash
+rm ~/obsidian/claude-code-vault/claude-insights/*retro*test-105*
+```
+
+---
+
+## Pass criteria
+
+All 4 phases checked. `source_session` resolves to a real UUID after the
+worktree was deleted. Python helper exits cleanly (no traceback in stderr).

--- a/plugins/obsidian-brain/scripts/dev-test/test-issue-101-manual.sh
+++ b/plugins/obsidian-brain/scripts/dev-test/test-issue-101-manual.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+# Manual smoke test for Issue #101 / PR #109 — source-session basename stability
+# Run AFTER: /dev-test install
+# Usage: bash scripts/dev-test/test-issue-101-manual.sh
+#
+# Validates the parts that can be checked without a fresh CC session:
+#   - Plugin cache has #101 helpers (_first_seen_date, _resolve_session_note_by_hash,
+#     _peek_frontmatter_{type,project_path}, _safe_getcwd, is_resumed_session(cwd=))
+#   - _first_seen_date marker write/idempotency/corruption/sid-validation/mode-self-heal
+#   - Resolver: type filter, project filter, type-missing legacy, ambiguous, single match
+#   - is_resumed_session: snapshot-only False, real True, collision False, cross-project False
+#   - get_session_context fallback uses marker date (not date.today)
+#   - SessionEnd integration (hook simulation): basename uses _first_seen_date
+#
+# For the parts that require a fresh CC session (live SessionStart hint, /recall
+# resolves UUID via on-disk note, real cross-midnight), see ./DEV-TEST-ISSUE-101.md.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  ⏭️  $1"; SKIP=$((SKIP + 1)); }
+
+# Locate the currently-installed plugin cache (the `dev-test install` target)
+CACHE_DIR=$(find ~/.claude/plugins/cache -type d -path "*/obsidian-brain/*" \
+    -not -path "*.bak*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null || true)
+if [ -z "$CACHE_DIR" ] || [ ! -d "$CACHE_DIR" ]; then
+    echo "❌ Could not locate obsidian-brain plugin cache."
+    echo "   Run /dev-test install first."
+    exit 1
+fi
+
+HOOK_DIR=$(find "$CACHE_DIR" -maxdepth 2 -type d -name hooks | sort -V | tail -1)
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "Issue #101 / PR #109 — Automated Validation"
+echo "═══════════════════════════════════════════════════════════════"
+echo "Plugin cache: $CACHE_DIR"
+echo "Hooks dir:    $HOOK_DIR"
+echo ""
+
+# Throwaway vault + isolated home for hook simulation
+FIXTURE=$(mktemp -d -t ob-issue-101.XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE/vault/claude-sessions"
+mkdir -p "$FIXTURE/home/.claude/obsidian-brain/sessions"
+chmod 700 "$FIXTURE/home/.claude/obsidian-brain/sessions"
+
+# ─── Test 1: Installed code surface ──────────────────────────────────
+echo "Test 1: Installed code surface"
+
+if grep -q "def _first_seen_date" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_first_seen_date() present"
+else
+    fail "_first_seen_date() missing — did /dev-test install pick up this branch?"
+fi
+
+if grep -q "def _resolve_session_note_by_hash" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_resolve_session_note_by_hash() present"
+else
+    fail "_resolve_session_note_by_hash() missing"
+fi
+
+if grep -q "def _peek_frontmatter_type" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_peek_frontmatter_type() present"
+else
+    fail "_peek_frontmatter_type() missing"
+fi
+
+if grep -q "def _peek_frontmatter_project_path" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_peek_frontmatter_project_path() present"
+else
+    fail "_peek_frontmatter_project_path() missing"
+fi
+
+if grep -q "def _safe_getcwd" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_safe_getcwd() present"
+else
+    fail "_safe_getcwd() missing"
+fi
+
+if python3 -c "
+import sys, inspect
+sys.path.insert(0, '$HOOK_DIR')
+import obsidian_utils
+sig = inspect.signature(obsidian_utils.is_resumed_session)
+sys.exit(0 if 'cwd' in sig.parameters else 1)
+"; then
+    pass "is_resumed_session(cwd=...) signature accepts cwd kwarg"
+else
+    fail "is_resumed_session signature missing cwd parameter"
+fi
+
+if grep -q '_first_seen_date(session_id)' "$HOOK_DIR/obsidian_session_log.py"; then
+    pass "obsidian_session_log.py wires _first_seen_date(session_id)"
+else
+    fail "SessionEnd not using _first_seen_date — Fix A wire-up missing"
+fi
+
+echo ""
+
+# ─── Test 2: Marker write + idempotency + cross-day stability ────────
+echo "Test 2: _first_seen_date marker write + idempotency + cross-day"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, os, json, datetime, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+from unittest.mock import patch
+import obsidian_utils
+
+sid = "issue101-test-$(date +%s)"
+d1 = obsidian_utils._first_seen_date(sid)
+d2 = obsidian_utils._first_seen_date(sid)
+print(f"d1={d1} d2={d2}")
+
+m = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid}.json"
+print(f"marker_exists={m.exists()}")
+print(f"marker_mode={oct(m.stat().st_mode)[-3:]}")
+payload = json.loads(m.read_text())
+print(f"has_first_seen_date={'first_seen_date' in payload}")
+print(f"has_first_seen_iso={'first_seen_iso' in payload}")
+
+# Cross-day: mock date.today() to advance, expect marker date unchanged
+class FakeDate:
+    @staticmethod
+    def today():
+        return datetime.date(2099, 1, 1)
+with patch.object(obsidian_utils.datetime, "date", FakeDate):
+    d3 = obsidian_utils._first_seen_date(sid)
+print(f"cross_day={d3}")
+PY
+)
+
+if echo "$RESULT" | grep -qE "d1=2[0-9]{3}-[0-9]{2}-[0-9]{2}"; then
+    D1=$(echo "$RESULT" | grep -oE "d1=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+    D2=$(echo "$RESULT" | grep -oE "d2=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+    if [ "$D1" = "$D2" ]; then
+        pass "_first_seen_date returns same value on second call (idempotent)"
+    else
+        fail "Idempotency broken: d1=$D1 d2=$D2"
+    fi
+else
+    fail "_first_seen_date did not return ISO-8601 date: $RESULT"
+fi
+
+echo "$RESULT" | grep -q "marker_exists=True" && pass "Marker file written" || fail "Marker file not written"
+echo "$RESULT" | grep -q "marker_mode=600" && pass "Marker mode is 0o600" || fail "Marker mode wrong: $(echo "$RESULT" | grep marker_mode)"
+echo "$RESULT" | grep -q "has_first_seen_date=True" && pass "Marker has first_seen_date field" || fail "Marker missing first_seen_date"
+echo "$RESULT" | grep -q "has_first_seen_iso=True" && pass "Marker has first_seen_iso field" || fail "Marker missing first_seen_iso"
+
+CROSS=$(echo "$RESULT" | grep -oE "cross_day=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+if [ "$CROSS" = "$D1" ] && [ "$CROSS" != "2099-01-01" ]; then
+    pass "Cross-day stability: marker beats date.today() (returns $CROSS, not 2099-01-01)"
+else
+    fail "Cross-day BROKEN: cross_day=$CROSS d1=$D1 (should match d1, must NOT be 2099-01-01)"
+fi
+
+echo ""
+
+# ─── Test 3: Marker corruption self-heal + sid validation ────────────
+echo "Test 3: Marker corruption self-heal + sid validation"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, datetime, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+# Corrupt marker → self-heal returns today
+sid = "corrupt-test-$(date +%s)"
+m = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid}.json"
+m.write_text("{not valid json}")
+d = obsidian_utils._first_seen_date(sid)
+expected = datetime.date.today().isoformat()
+print(f"corrupt_recover={d == expected}")
+
+# Path-traversal sid → falls back to today, no marker written
+bad_sid = "../../../etc/passwd"
+d2 = obsidian_utils._first_seen_date(bad_sid)
+print(f"bad_sid_fallback={d2 == expected}")
+m2 = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{bad_sid}.json"
+# Resolve to detect any write outside the safe dir
+import os
+print(f"no_traversal_write={not os.path.exists('/etc/passwd.json.tmp')}")
+
+# Loose-mode marker file → self-heals to 0o600 on read
+sid3 = "loose-mode-test-$(date +%s)"
+m3 = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid3}.json"
+m3.write_text('{"first_seen_date":"2026-04-20","first_seen_iso":"x"}')
+import os
+os.chmod(m3, 0o644)
+obsidian_utils._first_seen_date(sid3)
+print(f"marker_remode={oct(m3.stat().st_mode)[-3:]}")
+
+# Loose-mode dir → self-heals to 0o700
+sessions_dir = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions"
+os.chmod(sessions_dir, 0o755)
+obsidian_utils._first_seen_date("dirtest-$(date +%s)")
+print(f"dir_remode={oct(sessions_dir.stat().st_mode)[-3:]}")
+PY
+2>&1)
+
+echo "$RESULT" | grep -q "corrupt_recover=True" && pass "Corrupt marker → self-heals to today" || fail "Corruption recovery broken"
+echo "$RESULT" | grep -q "bad_sid_fallback=True" && pass "Path-traversal sid → safe today fallback" || fail "Path-traversal handling broken"
+echo "$RESULT" | grep -q "no_traversal_write=True" && pass "No file written outside marker dir" || fail "Path-traversal allowed file write"
+echo "$RESULT" | grep -q "marker_remode=600" && pass "Loose-mode marker file → chmod 0o600 self-heal" || fail "Marker mode self-heal broken: $(echo "$RESULT" | grep marker_remode)"
+echo "$RESULT" | grep -q "dir_remode=700" && pass "Loose-mode marker dir → chmod 0o700 self-heal" || fail "Dir mode self-heal broken: $(echo "$RESULT" | grep dir_remode)"
+
+echo ""
+
+# ─── Test 4: Resolver — type filter, project filter, ambiguous ───────
+echo "Test 4: _resolve_session_note_by_hash branches"
+
+RESULT=$(python3 - <<PY
+import sys, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+def write(p, fields):
+    with open(p, "w") as f:
+        f.write("---\n")
+        for k, v in fields.items():
+            f.write(f"{k}: {v}\n")
+        f.write("---\nbody\n")
+
+sessions = pathlib.Path("$FIXTURE/vault/claude-sessions")
+h = "abcd"
+
+# Branch A: snapshot-only with session-shaped name → (None, [])
+import shutil; shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-snap-{h}.md",
+      {"type": "claude-snapshot", "session_id": "x"})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/anything")
+print(f"snapshot_only={b is None and c == []}")
+
+# Branch B: single session match, cwd matches → (basename, [])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-session", "session_id": "real",
+       "project_path": '"/cwd/foo"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/foo")
+print(f"single_match={b == f'2026-04-20-foo-{h}' and c == []}")
+
+# Branch C: cross-project disambiguation by cwd
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-proj-a-{h}.md",
+      {"type": "claude-session", "session_id": "a",
+       "project_path": '"/cwd/a"'})
+write(sessions / f"2026-04-20-proj-b-{h}.md",
+      {"type": "claude-session", "session_id": "b",
+       "project_path": '"/cwd/b"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/a")
+print(f"disambiguate={b == f'2026-04-20-proj-a-{h}' and c == [f'2026-04-20-proj-b-{h}.md']}")
+
+# Branch D: type-missing legacy note treated as session
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-legacy-{h}.md",
+      {"session_id": "legacy", "project_path": '"/cwd/legacy"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/legacy")
+print(f"legacy_compat={b == f'2026-04-20-legacy-{h}'}")
+
+# Branch E: same-cwd ambiguous → (None, [all])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-x-{h}.md",
+      {"type": "claude-session", "session_id": "1",
+       "project_path": '"/cwd/x"'})
+write(sessions / f"2026-04-20-y-{h}.md",
+      {"type": "claude-session", "session_id": "2",
+       "project_path": '"/cwd/x"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/x")
+print(f"ambiguous={b is None and len(c) == 2}")
+
+# Branch F: empty sessions dir → (None, [])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/x")
+print(f"no_match={b is None and c == []}")
+PY
+)
+
+echo "$RESULT" | grep -q "snapshot_only=True" && pass "Snapshot-only with session-shaped name → excluded by type filter" || fail "Type filter broken: $(echo "$RESULT" | grep snapshot_only)"
+echo "$RESULT" | grep -q "single_match=True" && pass "Single session match returns clean basename" || fail "Single match broken"
+echo "$RESULT" | grep -q "disambiguate=True" && pass "Cross-project hash collision disambiguated by cwd" || fail "Cross-project disambiguation broken"
+echo "$RESULT" | grep -q "legacy_compat=True" && pass "Type-missing legacy note treated as session (backward-compat)" || fail "Legacy-note backward-compat broken"
+echo "$RESULT" | grep -q "ambiguous=True" && pass "Same-cwd ambiguous → (None, [all collisions])" || fail "Ambiguous resolution broken"
+echo "$RESULT" | grep -q "no_match=True" && pass "Empty sessions dir → (None, [])" || fail "No-match path broken"
+
+echo ""
+
+# ─── Test 5: is_resumed_session — all branches ───────────────────────
+echo "Test 5: is_resumed_session(cwd=) branches"
+
+RESULT=$(python3 - <<PY
+import sys, hashlib, pathlib, shutil
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+def write(p, fields):
+    with open(p, "w") as f:
+        f.write("---\n")
+        for k, v in fields.items():
+            f.write(f"{k}: {v}\n")
+        f.write("---\nbody\n")
+
+vault = pathlib.Path("$FIXTURE/vault")
+sessions = vault / "claude-sessions"
+
+sid = "test-resume-sid"
+h = hashlib.sha256(sid.encode()).hexdigest()[:4]
+
+# Snapshot-only with session-shaped name → False (type filter)
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-snapshot", "session_id": "different"})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"snapshot_only_false={r is False}")
+
+# Real session, cwd matches → True
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-session", "session_id": sid,
+       "project_path": '"/cwd/foo"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"real_session_true={r is True}")
+
+# Cross-project hash collision (cwd mismatch) → False
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-other-{h}.md",
+      {"type": "claude-session", "session_id": "other-sid",
+       "project_path": '"/some/other/path"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"cross_project_false={r is False}")
+
+# Same-project ambiguous collision pair → False (no unambiguous prior session)
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-x-{h}.md",
+      {"type": "claude-session", "session_id": "1",
+       "project_path": '"/cwd/foo"'})
+write(sessions / f"2026-04-20-y-{h}.md",
+      {"type": "claude-session", "session_id": "2",
+       "project_path": '"/cwd/foo"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"ambiguous_false={r is False}")
+PY
+)
+
+echo "$RESULT" | grep -q "snapshot_only_false=True" && pass "Snapshot-only → is_resumed_session=False (subsumes #86)" || fail "Snapshot type filter not blocking is_resumed_session"
+echo "$RESULT" | grep -q "real_session_true=True" && pass "Real session note → is_resumed_session=True" || fail "Real session detection broken"
+echo "$RESULT" | grep -q "cross_project_false=True" && pass "Cross-project hash collision → is_resumed_session=False (cwd-strict)" || fail "Cross-project filter broken (closes #110 concern)"
+echo "$RESULT" | grep -q "ambiguous_false=True" && pass "Ambiguous collision pair → is_resumed_session=False" || fail "Ambiguous handling broken"
+
+echo ""
+
+# ─── Test 6: get_session_context fallback uses marker date ───────────
+echo "Test 6: get_session_context fallback uses _first_seen_date (cross-midnight)"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, json, pathlib, datetime, shutil
+sys.path.insert(0, "$HOOK_DIR")
+from unittest.mock import patch
+import obsidian_utils
+
+# Pre-seed marker for a session with first_seen=day-N, then mock today=day-N+2
+sid = "cross-midnight-sid-$(date +%s)"
+marker_dir = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions"
+(marker_dir / f"{sid}.json").write_text(
+    json.dumps({"first_seen_date": "2026-04-20", "first_seen_iso": "x"})
+)
+
+class FakeDate:
+    @staticmethod
+    def today():
+        return datetime.date(2026, 4, 22)
+
+# Clean vault for fallback path (no on-disk session note → resolver returns None)
+vault = pathlib.Path("$FIXTURE/vault")
+sessions = vault / "claude-sessions"
+shutil.rmtree(sessions); sessions.mkdir()
+
+# get_session_context resolves sid via _get_session_id_fast and project via
+# canonical_project_name — patch both so the fallback exercises marker date.
+with patch.object(obsidian_utils, "_get_session_id_fast", return_value=sid), \
+     patch.object(obsidian_utils, "canonical_project_name", return_value="test-project"), \
+     patch.object(obsidian_utils, "cache_get", return_value=None), \
+     patch.object(obsidian_utils, "cache_set", return_value=None), \
+     patch.object(obsidian_utils.datetime, "date", FakeDate):
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+
+basename = ctx.get("session_note_name", "")
+print(f"basename={basename}")
+print(f"starts_with_marker_date={basename.startswith('2026-04-20-')}")
+print(f"NOT_today={'2026-04-22' not in basename}")
+PY
+)
+
+echo "$RESULT" | grep -q "starts_with_marker_date=True" && pass "Fallback basename starts with marker date (2026-04-20)" || fail "Fallback ignored marker: $(echo "$RESULT" | grep basename)"
+echo "$RESULT" | grep -q "NOT_today=True" && pass "Fallback basename does NOT use today's date (2026-04-22)" || fail "Fallback used today instead of marker"
+
+echo ""
+
+# ─── Test 7: SessionEnd hook simulation — basename uses marker ───────
+echo "Test 7: SessionEnd hook simulation — full write path"
+
+# Clean vault sessions dir of fixtures from earlier tests so the find
+# at the bottom only sees what THIS hook invocation wrote.
+rm -f "$FIXTURE/vault/claude-sessions/"*.md
+
+# Pre-seed a marker with yesterday-equivalent date
+SIM_SID="sim-sessionend-$(date +%s)"
+MARKER_DIR="$FIXTURE/home/.claude/obsidian-brain/sessions"
+echo '{"first_seen_date":"2026-04-20","first_seen_iso":"2026-04-20T22:00:00Z"}' \
+    > "$MARKER_DIR/$SIM_SID.json"
+chmod 600 "$MARKER_DIR/$SIM_SID.json"
+
+# Synthetic config + transcript
+CFG_DIR="$FIXTURE/home/.claude"
+cat > "$CFG_DIR/obsidian-brain-config.json" <<JSON
+{
+  "vault_path": "$FIXTURE/vault",
+  "sessions_folder": "claude-sessions",
+  "insights_folder": "claude-insights",
+  "min_messages_to_log": 0,
+  "min_session_duration_seconds": 0
+}
+JSON
+
+TRANSCRIPT="$FIXTURE/transcript.jsonl"
+cat > "$TRANSCRIPT" <<EOF
+{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-04-20T22:00:00Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"timestamp":"2026-04-20T22:00:05Z"}
+EOF
+
+# Simulate SessionEnd
+HOOK_INPUT=$(cat <<JSON
+{"hook_event_name":"SessionEnd","session_id":"$SIM_SID","cwd":"$FIXTURE","transcript_path":"$TRANSCRIPT"}
+JSON
+)
+
+if HOME="$FIXTURE/home" echo "$HOOK_INPUT" | python3 "$HOOK_DIR/obsidian_session_log.py" >/dev/null 2>&1; then
+    pass "SessionEnd hook ran without error"
+else
+    skip "SessionEnd hook returned non-zero (likely benign — filter thresholds, no anthropic key for summarization)"
+fi
+
+# Whether or not summarization succeeded, the raw note must exist with marker-dated basename
+WROTE=$(find "$FIXTURE/vault/claude-sessions" -name "2026-04-20-*.md" 2>/dev/null | head -1)
+if [ -n "$WROTE" ]; then
+    pass "Vault note written with marker date prefix: $(basename "$WROTE")"
+else
+    BAD=$(find "$FIXTURE/vault/claude-sessions" -name "*.md" 2>/dev/null | head -1)
+    if [ -n "$BAD" ]; then
+        fail "Vault note basename uses wrong date: $(basename "$BAD") — expected 2026-04-20-*"
+    else
+        skip "No vault note written (likely below message threshold, OK)"
+    fi
+fi
+
+echo ""
+
+# ─── Test 8: _safe_getcwd handles cwd-gone ───────────────────────────
+echo "Test 8: _safe_getcwd cwd-gone safety"
+
+RESULT=$(python3 - <<PY
+import sys, os
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+# Normal case
+cwd1 = obsidian_utils._safe_getcwd()
+print(f"normal_nonempty={bool(cwd1)}")
+
+# Simulate cwd-gone
+def fake_getcwd_raises():
+    raise FileNotFoundError("cwd is gone")
+
+orig = os.getcwd
+os.getcwd = fake_getcwd_raises
+cwd2 = obsidian_utils._safe_getcwd()
+os.getcwd = orig
+print(f"cwd_gone_returns_empty={cwd2 == ''}")
+PY
+)
+
+echo "$RESULT" | grep -q "normal_nonempty=True" && pass "_safe_getcwd returns non-empty when cwd is healthy" || fail "_safe_getcwd broken in normal case"
+echo "$RESULT" | grep -q "cwd_gone_returns_empty=True" && pass "_safe_getcwd returns '' on FileNotFoundError" || fail "_safe_getcwd does not handle cwd-gone"
+
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "❌ One or more checks failed. Inspect the log above, fix, and re-run."
+    exit 1
+fi
+
+cat <<'NEXT'
+
+✅ Automated checks passed. Next: run the live Claude Code smoke flow in
+   ./DEV-TEST-ISSUE-101.md (the parts that require an actual fresh CC session
+   to exercise SessionStart hint, real /recall against a non-fixture vault,
+   and end-to-end cross-midnight via real wall-clock advance).
+NEXT

--- a/plugins/obsidian-brain/scripts/dev-test/test-issue-105-manual.sh
+++ b/plugins/obsidian-brain/scripts/dev-test/test-issue-105-manual.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# Manual smoke test for Issue #105 — _get_session_id_fast cwd-gone resilience
+# Run AFTER: /dev-test install
+# Usage: bash scripts/dev-test/test-issue-105-manual.sh
+#
+# Validates the parts that can be checked without a fresh CC session:
+#   Phase A: _resolve_project_basename — happy / env-fallback / both-fail
+#   Phase B: _recent_bootstrap_sid — zero / one / two / tmp-skip / stale
+#   Phase C: _resolve_session_id end-to-end with REAL OS-level cwd deletion
+#   Phase D: thin-wrapper contracts for _get_session_id_fast / _slow_path_newest_sid
+#   Phase E: insight-saver bash prelude integration under wedged cwd
+#
+# For the live-CC steps (real worktree deletion, real /retro), see
+# ./DEV-TEST-ISSUE-105.md.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+
+CACHE_DIR=$(find ~/.claude/plugins/cache -type d -path "*/obsidian-brain/*" \
+    -not -path "*.bak*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null || true)
+if [ -z "$CACHE_DIR" ] || [ ! -d "$CACHE_DIR" ]; then
+    echo "❌ Could not locate obsidian-brain plugin cache."
+    echo "   Run /dev-test install first."
+    exit 1
+fi
+
+HOOK_DIR=$(find "$CACHE_DIR" -maxdepth 2 -type d -name hooks | sort -V | tail -1)
+if [ -z "$HOOK_DIR" ] || [ ! -d "$HOOK_DIR" ] || [ ! -r "$HOOK_DIR/obsidian_utils.py" ]; then
+    echo "❌ Could not locate a valid hooks directory in the obsidian-brain plugin cache."
+    echo "   Expected a readable file at: $HOOK_DIR/obsidian_utils.py"
+    echo "   Run /dev-test install first, or verify the plugin cache layout under:"
+    echo "   $CACHE_DIR"
+    exit 1
+fi
+
+# Sanity-check that the cache has the issue #105 functions before running
+# Phase A-E. Without this, AttributeErrors get swallowed by the per-assertion
+# `2>/dev/null` and surface as misleading "expected '<X>', got ''" failures.
+PYTHONPATH="$HOOK_DIR" python3 -c \
+    'import obsidian_utils; assert hasattr(obsidian_utils, "_resolve_project_basename"), "missing _resolve_project_basename"' \
+    >/dev/null 2>&1 || {
+    echo "❌ Plugin cache at $HOOK_DIR is missing issue #105 functions."
+    echo "   Run /dev-test install in a sibling Claude Code session to sync"
+    echo "   the feature branch into the cache, then re-run this script."
+    exit 1
+}
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "Issue #105 — cwd-gone session-id resolution"
+echo "═══════════════════════════════════════════════════════════════"
+echo "Plugin cache: $CACHE_DIR"
+echo "Hooks dir:    $HOOK_DIR"
+echo ""
+
+# Throwaway fixture root — isolated HOME so sid-* bootstraps don't pollute.
+FIXTURE=$(mktemp -d -t ob-issue-105.XXXXXX)
+trap 'cd "$HOME" 2>/dev/null; rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE/home/.claude/obsidian-brain"
+chmod 700 "$FIXTURE/home/.claude/obsidian-brain"
+
+run_py() {
+    # Run python3 with HOME and PYTHONPATH redirected so the installed
+    # cache's obsidian_utils sees our fixture's secure dir.
+    HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 "$@"
+}
+
+# ─── Phase A: _resolve_project_basename ───────────────────────────────
+echo "Phase A: _resolve_project_basename"
+
+# A1: happy path
+mkdir -p "$FIXTURE/some-project"
+A1=$(cd "$FIXTURE/some-project" && run_py -c \
+    'import obsidian_utils; print(obsidian_utils._resolve_project_basename())' 2>/dev/null || true)
+if [ "$A1" = "some-project" ]; then
+    pass "A1 happy path returns cwd basename"
+else
+    fail "A1 happy path: expected 'some-project', got '$A1'"
+fi
+
+# A2: env fallback (cwd raises → CLAUDE_PROJECT_DIR basename)
+A2=$(CLAUDE_PROJECT_DIR="/tmp/fake-dir/my-proj" run_py -c '
+import os, obsidian_utils
+def _raise(*a, **kw): raise FileNotFoundError("cwd")
+os.getcwd = _raise
+print(obsidian_utils._resolve_project_basename())
+' 2>/dev/null || true)
+if [ "$A2" = "my-proj" ]; then
+    pass "A2 env-fallback returns CLAUDE_PROJECT_DIR basename"
+else
+    fail "A2 env-fallback: expected 'my-proj', got '$A2'"
+fi
+
+# A3: both unavailable → None
+A3=$(unset CLAUDE_PROJECT_DIR; run_py -c '
+import os, obsidian_utils
+def _raise(*a, **kw): raise FileNotFoundError("cwd")
+os.getcwd = _raise
+print(repr(obsidian_utils._resolve_project_basename()))
+' 2>/dev/null || true)
+if [ "$A3" = "None" ]; then
+    pass "A3 both-fail returns None"
+else
+    fail "A3 both-fail: expected 'None', got '$A3'"
+fi
+echo ""
+
+# ─── Phase B: _recent_bootstrap_sid ───────────────────────────────────
+echo "Phase B: _recent_bootstrap_sid"
+
+BDIR="$FIXTURE/home/.claude/obsidian-brain"
+
+# B1: zero recent files → None
+rm -f "$BDIR"/sid-*  # ensure clean
+B1=$(run_py -c \
+    'import obsidian_utils; print(repr(obsidian_utils._recent_bootstrap_sid()))' 2>/dev/null || true)
+if [ "$B1" = "None" ]; then
+    pass "B1 zero-recent returns None"
+else
+    fail "B1 zero-recent: expected 'None', got '$B1'"
+fi
+
+# B2: exactly one recent → returns the SID
+echo -n "test-sid-b2" > "$BDIR/sid-projB2"
+B2=$(run_py -c \
+    'import obsidian_utils; print(obsidian_utils._recent_bootstrap_sid())' 2>/dev/null || true)
+if [ "$B2" = "test-sid-b2" ]; then
+    pass "B2 exactly-one returns SID"
+else
+    fail "B2 exactly-one: expected 'test-sid-b2', got '$B2'"
+fi
+
+# B3: two recent → None (strict)
+echo -n "test-sid-b3" > "$BDIR/sid-projB3"
+B3=$(run_py -c \
+    'import obsidian_utils; print(repr(obsidian_utils._recent_bootstrap_sid()))' 2>/dev/null || true)
+if [ "$B3" = "None" ]; then
+    pass "B3 two-recent returns None (strict)"
+else
+    fail "B3 two-recent: expected 'None', got '$B3'"
+fi
+
+# B4: tmp partial alongside one recent → still exactly-one
+rm -f "$BDIR"/sid-*
+echo -n "test-sid-b4" > "$BDIR/sid-projB4"
+echo -n "garbage" > "$BDIR/.ob-sid-b4.tmp"
+B4=$(run_py -c \
+    'import obsidian_utils; print(obsidian_utils._recent_bootstrap_sid())' 2>/dev/null || true)
+if [ "$B4" = "test-sid-b4" ]; then
+    pass "B4 tmp-partial skipped"
+else
+    fail "B4 tmp-partial: expected 'test-sid-b4', got '$B4'"
+fi
+
+# B5: stale (mtime > window seconds ago) → None
+rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+echo -n "test-sid-b5" > "$BDIR/sid-projB5"
+# Set mtime to 700 seconds ago (window default = 600)
+touch -t "$(date -v-700S +%Y%m%d%H%M.%S 2>/dev/null || date -d '700 seconds ago' +%Y%m%d%H%M.%S)" "$BDIR/sid-projB5"
+B5=$(run_py -c \
+    'import obsidian_utils; print(repr(obsidian_utils._recent_bootstrap_sid()))' 2>/dev/null || true)
+if [ "$B5" = "None" ]; then
+    pass "B5 stale-mtime returns None"
+else
+    fail "B5 stale-mtime: expected 'None', got '$B5'"
+fi
+echo ""
+
+# ─── Phase C: _resolve_session_id with REAL cwd deletion ──────────────
+echo "Phase C: _resolve_session_id (real OS deletion)"
+
+# Each Phase C assertion runs in a subshell so cwd-deletion fallout doesn't
+# wedge the parent script.
+
+# C1: cwd-gone + recent bootstrap → returns SID
+C1=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    echo -n "test-sid-c1" > "$BDIR/sid-projC1"
+    (
+        TMP=$(mktemp -d -t ob-c1.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"  # cwd is now gone
+        unset CLAUDE_PROJECT_DIR
+        HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; print(obsidian_utils._resolve_session_id())' 2>/dev/null || true
+    )
+)
+if [ "$C1" = "test-sid-c1" ]; then
+    pass "C1 cwd-gone + recent bootstrap → SID via layer 4"
+else
+    fail "C1 cwd-gone + bootstrap: expected 'test-sid-c1', got '$C1'"
+fi
+
+# C2: cwd-gone + no recent bootstrap → 'unknown'
+C2=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    (
+        TMP=$(mktemp -d -t ob-c2.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"
+        unset CLAUDE_PROJECT_DIR
+        HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; print(obsidian_utils._resolve_session_id())' 2>/dev/null || true
+    )
+)
+if [ "$C2" = "unknown" ]; then
+    pass "C2 cwd-gone + no bootstrap → 'unknown'"
+else
+    fail "C2 cwd-gone + no bootstrap: expected 'unknown', got '$C2'"
+fi
+
+# C3: cwd-gone + CLAUDE_PROJECT_DIR set + matching JSONL → returns via slow path
+C3=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    PROJ="projC3"
+    CC_DIR="$FIXTURE/home/.claude/projects/-Users-test-$PROJ"
+    mkdir -p "$CC_DIR"
+    echo "{}" > "$CC_DIR/test-sid-c3.jsonl"
+    (
+        TMP=$(mktemp -d -t ob-c3.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"
+        CLAUDE_PROJECT_DIR="/tmp/fake/$PROJ" HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; print(obsidian_utils._resolve_session_id())' 2>/dev/null || true
+    )
+)
+if [ "$C3" = "test-sid-c3" ]; then
+    pass "C3 cwd-gone + env + JSONL → SID via layer 1+3"
+else
+    fail "C3 cwd-gone + env + JSONL: expected 'test-sid-c3', got '$C3'"
+fi
+
+# C4: cwd valid + bootstrap valid → no behavior change (happy path)
+C4=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    PROJ="projC4"
+    CC_DIR="$FIXTURE/home/.claude/projects/-Users-test-$PROJ"
+    mkdir -p "$CC_DIR"
+    echo "{}" > "$CC_DIR/test-sid-c4.jsonl"
+    echo -n "test-sid-c4" > "$BDIR/sid-$PROJ"
+    mkdir -p "$FIXTURE/$PROJ"
+    cd "$FIXTURE/$PROJ"
+    HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+        'import obsidian_utils; print(obsidian_utils._resolve_session_id())' 2>/dev/null || true
+)
+if [ "$C4" = "test-sid-c4" ]; then
+    pass "C4 happy path → SID via layer 2 (no behavior change)"
+else
+    fail "C4 happy path: expected 'test-sid-c4', got '$C4'"
+fi
+echo ""
+
+# ─── Phase D: thin-wrapper contracts ──────────────────────────────────
+echo "Phase D: thin-wrapper contracts unchanged"
+
+# D1: _get_session_id_fast still callable, returns string
+D1=$(cd "$FIXTURE" && run_py -c \
+    'import obsidian_utils; r = obsidian_utils._get_session_id_fast(); print(type(r).__name__)' 2>/dev/null || true)
+if [ "$D1" = "str" ]; then
+    pass "D1 _get_session_id_fast returns str"
+else
+    fail "D1 _get_session_id_fast: expected 'str', got '$D1'"
+fi
+
+# D2: _slow_path_newest_sid still callable, returns string
+D2=$(cd "$FIXTURE" && run_py -c \
+    'import obsidian_utils; r = obsidian_utils._slow_path_newest_sid(); print(type(r).__name__)' 2>/dev/null || true)
+if [ "$D2" = "str" ]; then
+    pass "D2 _slow_path_newest_sid returns str"
+else
+    fail "D2 _slow_path_newest_sid: expected 'str', got '$D2'"
+fi
+
+# D3: 'unknown' sentinel preserved when no signal at all
+rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+D3=$(cd "$FIXTURE/some-project" && run_py -c '
+import obsidian_utils
+print(obsidian_utils._slow_path_newest_sid())
+' 2>/dev/null || true)
+if [ "$D3" = "unknown" ]; then
+    pass "D3 'unknown' sentinel preserved"
+else
+    fail "D3 'unknown' sentinel: expected 'unknown', got '$D3'"
+fi
+echo ""
+
+# ─── Phase E: insight-saver bash prelude under wedged cwd ─────────────
+echo "Phase E: insight-saver bash prelude integration"
+
+# Replicates the exact bash prelude from compress/decide/error-log/retro
+# SKILL.md: cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"; python3 -c '...'
+
+# E1: bash prelude under wedged cwd + recent bootstrap → real SID (NOT 'unknown')
+E1=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    echo -n "test-sid-e1" > "$BDIR/sid-projE1"
+    (
+        TMP=$(mktemp -d -t ob-e1.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"
+        unset CLAUDE_PROJECT_DIR
+        # Defensive variant of the SKILL.md prelude (the SKILL.md form is
+        # `cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"`; here we
+        # add `|| echo /` so the cd lands at / instead of no-op'ing under
+        # `set -euo pipefail` + wedged-cwd, allowing python3 to launch and
+        # exercise the resolver chain — that's what we're actually testing).
+        cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd 2>/dev/null || echo /)" 2>/dev/null
+        HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; print(obsidian_utils._get_session_id_fast())' 2>/dev/null || true
+    )
+)
+if [ "$E1" = "test-sid-e1" ]; then
+    pass "E1 bash prelude + cwd-gone + bootstrap → real SID (no metadata loss)"
+else
+    fail "E1 bash prelude integration: expected 'test-sid-e1', got '$E1'"
+fi
+
+# E2: same scenario without recent bootstrap → 'unknown' (graceful, no crash)
+E2=$(
+    rm -f "$BDIR"/sid-* "$BDIR"/.ob-sid-*.tmp
+    (
+        TMP=$(mktemp -d -t ob-e2.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"
+        unset CLAUDE_PROJECT_DIR
+        cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd 2>/dev/null || echo /)" 2>/dev/null
+        HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; print(obsidian_utils._get_session_id_fast())' 2>/dev/null || true
+    )
+)
+if [ "$E2" = "unknown" ]; then
+    pass "E2 bash prelude + cwd-gone + no bootstrap → 'unknown' (graceful)"
+else
+    fail "E2 bash prelude graceful: expected 'unknown', got '$E2'"
+fi
+
+# E3: confirm Python subprocess exits cleanly (no traceback bleed)
+E3_EXIT=$(
+    (
+        TMP=$(mktemp -d -t ob-e3.XXXXXX)
+        cd "$TMP"
+        rmdir "$TMP"
+        unset CLAUDE_PROJECT_DIR
+        cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd 2>/dev/null || echo /)" 2>/dev/null
+        HOME="$FIXTURE/home" PYTHONPATH="$HOOK_DIR" python3 -c \
+            'import obsidian_utils; obsidian_utils._get_session_id_fast()' >/dev/null 2>&1
+        echo $?
+    )
+)
+if [ "$E3_EXIT" = "0" ]; then
+    pass "E3 Python exits cleanly under wedged cwd (no FileNotFoundError)"
+else
+    fail "E3 Python exit: expected 0, got $E3_EXIT"
+fi
+echo ""
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════════════"
+echo "Issue #105 fixture: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi

--- a/plugins/obsidian-brain/scripts/tune_compress_rank_gap.py
+++ b/plugins/obsidian-brain/scripts/tune_compress_rank_gap.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Tuning harness for /compress Step 3.5 rank-gap delta guard.
+
+Reads scripts/compress_rank_gap_corpus.json, runs each query against the
+live vault index using the same search_vault() path as /compress SKILL.md
+Step 3.5, and prints a markdown table showing true-positive / false-
+positive / false-negative counts at each candidate MIN_RANK_DELTA value.
+
+Usage:
+    python3 scripts/tune_compress_rank_gap.py
+
+No arguments. Reads vault_path from ~/.claude/obsidian-brain-config.json
+and the corpus from scripts/compress_rank_gap_corpus.json (relative to
+repo root).
+
+Exit codes: always 0. This is a reporting tool, not a CI gate.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Path bootstrap: add hooks/ so we can import the plugin's modules
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from compress_guard import is_high_confidence_match  # noqa: E402
+from obsidian_utils import load_config  # noqa: E402
+from vault_index import ensure_index, search_vault  # noqa: E402
+
+
+THRESHOLD_GRID = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0]
+CORPUS_PATH = REPO_ROOT / "scripts" / "compress_rank_gap_corpus.json"
+
+
+def _run_query(db, query):
+    """Run the same search that SKILL.md Step 3.5 runs. Returns sorted results."""
+    results = search_vault(db, query, note_type="claude-insight", limit=3)
+    results += search_vault(db, query, note_type="claude-decision", limit=3)
+    results.sort(key=lambda r: r["rank"])
+    return results
+
+
+def _score_corpus(corpus_entries, results_by_id, min_delta):
+    """Score the corpus at a given MIN_RANK_DELTA threshold."""
+    tp = tn = fp = fn = skipped = 0
+    for entry in corpus_entries:
+        results = results_by_id.get(entry["id"])
+        if not results:
+            skipped += 1
+            continue
+        predicted = is_high_confidence_match(results, min_delta=min_delta)
+        expected = entry["expected_match"]
+        if predicted and expected:
+            tp += 1
+        elif predicted and not expected:
+            fp += 1
+        elif not predicted and expected:
+            fn += 1
+        else:
+            tn += 1
+    return {"tp": tp, "tn": tn, "fp": fp, "fn": fn, "skipped": skipped}
+
+
+def main():
+    # Resolve vault path
+    try:
+        config = load_config()
+    except Exception as exc:
+        print(f"Could not load ~/.claude/obsidian-brain-config.json: {exc}")
+        print("Run /obsidian-setup first.")
+        return 0
+    vault_path = config.get("vault_path")
+    if not vault_path or not os.path.isdir(vault_path):
+        print(f"Config vault_path missing or invalid: {vault_path!r}")
+        return 0
+
+    # Load corpus
+    if not CORPUS_PATH.exists():
+        print(f"Corpus not found: {CORPUS_PATH}")
+        return 0
+    with open(CORPUS_PATH, "r", encoding="utf-8") as fh:
+        corpus = json.load(fh)
+    entries = corpus.get("queries", [])
+    if not entries:
+        print("Corpus is empty. Add queries to scripts/compress_rank_gap_corpus.json.")
+        return 0
+
+    # Open the vault index
+    folders = [
+        config.get("sessions_folder", "claude-sessions"),
+        config.get("insights_folder", "claude-insights"),
+    ]
+    db = ensure_index(vault_path, folders)
+
+    # Run each query once, cache results
+    print(f"# Tuning sweep — {len(entries)} queries against {vault_path}\n")
+    print("## Per-query results\n")
+    print("| id | query | top rank | #2 rank | delta | expected |")
+    print("|---|---|---|---|---|---|")
+    results_by_id = {}
+    for entry in entries:
+        results = _run_query(db, entry["query"])
+        results_by_id[entry["id"]] = results
+        if not results:
+            print(f"| {entry['id']} | `{entry['query']}` | — | — | — | {entry['expected_match']} (SKIPPED: no results) |")
+            continue
+        top_rank = results[0]["rank"]
+        if len(results) >= 2:
+            second_rank = results[1]["rank"]
+            delta = abs(top_rank) - abs(second_rank)
+            print(f"| {entry['id']} | `{entry['query']}` | {top_rank:.2f} | {second_rank:.2f} | {delta:.2f} | {entry['expected_match']} |")
+        else:
+            print(f"| {entry['id']} | `{entry['query']}` | {top_rank:.2f} | — | — | {entry['expected_match']} |")
+
+    # All-empty diagnostic (before sweep so the user sees it)
+    total_skipped = sum(1 for r in results_by_id.values() if not r)
+    if total_skipped == len(entries):
+        print("\nWARN: All corpus queries returned no results from the vault.")
+        print("      Check that vault_path is correct and the index is populated.")
+        print("      Run /vault-reindex if the index needs a rebuild.\n")
+
+    # Sweep thresholds
+    print("\n## Threshold sweep\n")
+    print("| MIN_RANK_DELTA | TP | TN | FP | FN | skipped | score (TP+TN)/total | repro #45 |")
+    print("|---|---|---|---|---|---|---|---|")
+    repro_results = results_by_id.get("replay-pr43-snapshot", [])
+    for t in THRESHOLD_GRID:
+        score = _score_corpus(entries, results_by_id, min_delta=t)
+        total = score["tp"] + score["tn"] + score["fp"] + score["fn"]
+        if total == 0:
+            ratio = float("nan")
+        else:
+            ratio = (score["tp"] + score["tn"]) / total
+        if repro_results:
+            repro_pass = is_high_confidence_match(repro_results, min_delta=t)
+        else:
+            repro_pass = "skipped"
+        print(
+            f"| {t:.2f} | {score['tp']} | {score['tn']} | {score['fp']} | {score['fn']} | "
+            f"{score['skipped']} | {ratio:.2f} | {repro_pass} |"
+        )
+
+    print("\n## Selection guidance\n")
+    print("- Hard constraint: MIN_RANK_DELTA must be < 4.75 so the issue #45")
+    print("  repro case resolves True (see spec).")
+    print("- Pick the feasible threshold with the best (TP+TN)/total score.")
+    print("- Ties broken toward lower thresholds (more permissive = fewer")
+    print("  silent duplicates; users can always decline the update prompt).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/obsidian-brain/scripts/vault_doctor.py
+++ b/plugins/obsidian-brain/scripts/vault_doctor.py
@@ -181,6 +181,10 @@ def main() -> int:
                     "reason": i.reason,
                     "confidence": i.confidence,
                     "unresolved": i.extra.get("unresolved", False),
+                    "capture_signal": i.extra.get("capture_signal", ""),
+                    "capture_confidence": i.extra.get("capture_confidence", 0.0),
+                    "convergence_warning": i.extra.get("convergence_warning", False),
+                    "convergence_count": i.extra.get("convergence_count", 0),
                 }
                 for issues in issues_by_check.values() for i in issues
             ],

--- a/plugins/obsidian-brain/scripts/vault_doctor_checks/snapshot_integrity.py
+++ b/plugins/obsidian-brain/scripts/vault_doctor_checks/snapshot_integrity.py
@@ -106,6 +106,22 @@ def scan(vault_path: str, sessions_folder: str, insights_folder: str,
 
     # Index all session/snapshot files once to avoid O(N^2) scans
     sessions_by_id: dict[str, dict] = {}
+    # Issue #81: track sids that appear on more than one session note.
+    # ``sessions_by_id`` picks a filesystem-order-dependent winner when
+    # two notes share a sid; comparing a snapshot's backlink against an
+    # arbitrary winner would produce a confidently wrong
+    # snapshot-broken-backlink fix. Consumers guard on this set to
+    # route colliding sids to an unresolved snapshot-orphan instead.
+    #
+    # Collision detection is PROJECT-BLIND: two session notes sharing a
+    # sid across different projects (re-imports, project-rename
+    # migrations) would otherwise have one collider filtered out by
+    # ``--project=foo`` and resurrect an arbitrary winner inside the
+    # filtered scan. ``_all_sids_seen`` therefore indexes every session
+    # note regardless of project; emission indices
+    # (``sessions_by_id`` / ``snapshots``) remain project-filtered.
+    _sid_collisions: set[str] = set()
+    _all_sids_seen: set[str] = set()
     snapshots: list[dict] = []
     for p in sess_dir.iterdir():
         if p.suffix != ".md":
@@ -116,12 +132,22 @@ def scan(vault_path: str, sessions_folder: str, insights_folder: str,
         fm = _parse_fm(text)
         if not fm:
             continue
+        type_ = fm.get("type", "")
+        sid = fm.get("session_id", "") if type_ == "claude-session" else ""
+        # Project-blind collision detection (see block comment above).
+        if sid:
+            if sid in _all_sids_seen:
+                _sid_collisions.add(sid)
+            else:
+                _all_sids_seen.add(sid)
+        # Project-filtered emission indices.
         if not _project_matches(fm.get("project", ""), project):
             continue
-        type_ = fm.get("type", "")
         if type_ == "claude-session":
-            sid = fm.get("session_id", "")
-            if sid:
+            # First-writer-wins: the winner is retained as the
+            # (unreliable) lookup target; consumers short-circuit via
+            # ``_sid_collisions`` before trusting it.
+            if sid and sid not in sessions_by_id:
                 sessions_by_id[sid] = {
                     "path": str(p), "fm": fm, "stem": p.stem, "text": text,
                 }
@@ -137,6 +163,50 @@ def scan(vault_path: str, sessions_folder: str, insights_folder: str,
         fm = snap["fm"]
         sid = fm.get("session_id", "")
         project_name = fm.get("project", "")
+        # Empty-sid guard (parity with snapshot_migration.py §3): a
+        # snapshot with no session_id in frontmatter can't be resolved
+        # at all. Emit a specific unresolved reason so operators aren't
+        # told "no session note matches session_id=''" (misleading).
+        if not sid:
+            issues.append(Issue(
+                check="snapshot-orphan",
+                note_path=snap["path"],
+                project=project_name,
+                current_source="session_id=(empty)",
+                proposed_source="",
+                reason="snapshot has no session_id in frontmatter",
+                confidence=0.0,
+                extra={"unresolved": True},
+            ))
+            continue
+        # Issue #81: colliding sids must be routed to an unresolved
+        # "ambiguous parent" snapshot-orphan BEFORE any parent-based
+        # check (missing-parent below, broken-backlink further down) —
+        # otherwise the snapshot's ``source_session_note`` would be
+        # compared against an arbitrary ``sessions_by_id`` winner and a
+        # confidently-wrong fix would be proposed. The sid is included
+        # in the reason verbatim so operators can grep the vault.
+        if sid in _sid_collisions:
+            # Both collision and missing-parent set ``extra["unresolved"]
+            # = True``, so neither auto-applies. The numeric confidence
+            # is operator-facing signal only: 0.0 for collisions (more
+            # candidates than we can choose between) vs 0.9 for
+            # missing-parent (high confidence in the orphan classification).
+            issues.append(Issue(
+                check="snapshot-orphan",
+                note_path=snap["path"],
+                project=project_name,
+                current_source=f"session_id={sid}",
+                proposed_source="",
+                reason=(
+                    f"ambiguous parent — multiple session notes share "
+                    f"session_id={sid!r}; resolve by deduping the colliding "
+                    f"session notes in the sessions folder"
+                ),
+                confidence=0.0,
+                extra={"unresolved": True},
+            ))
+            continue
         parent_session = sessions_by_id.get(sid)
 
         if not parent_session:
@@ -204,6 +274,11 @@ def scan(vault_path: str, sessions_folder: str, insights_folder: str,
             snaps_by_session.setdefault(sid, []).append(f"[[{snap['stem']}]]")
 
     for sid, sess in sessions_by_id.items():
+        # Issue #81: skip colliding sids — we cannot declare either
+        # session the authoritative parent, so proposing a snapshots:
+        # list edit would be a 50/50 guess.
+        if sid in _sid_collisions:
+            continue
         on_disk = sorted(snaps_by_session.get(sid, []))
         in_frontmatter = sess["fm"].get("snapshots") or []
         if not isinstance(in_frontmatter, list):

--- a/plugins/obsidian-brain/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/plugins/obsidian-brain/scripts/vault_doctor_checks/snapshot_migration.py
@@ -15,7 +15,6 @@ filenames still resolve after migration.
 from __future__ import annotations
 
 import datetime
-import hashlib
 import os
 import re
 import shutil
@@ -73,15 +72,6 @@ def _hhmmss_from_mtime(p: Path) -> str:
     return datetime.datetime.fromtimestamp(ts).strftime("%H%M%S")
 
 
-def _short_session_hash(session_id: str) -> str:
-    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:4] if session_id else "e3b0"
-
-
-def _slugify(text: str) -> str:
-    """Minimal inline copy; avoids import cycles with hooks/ module."""
-    return re.sub(r"[^a-zA-Z0-9]+", "-", text.strip()).strip("-").lower() or "project"
-
-
 def scan(vault_path, sessions_folder, insights_folder, days, project=None):
     sess_dir = Path(vault_path) / sessions_folder
     if not sess_dir.is_dir():
@@ -91,6 +81,21 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
 
     all_md = [p for p in sess_dir.iterdir() if p.suffix == ".md"]
     sessions_by_id: dict[str, Path] = {}
+    # Issue #81: track sids that appear on more than one session note. A
+    # filesystem-order-dependent ``sessions_by_id`` winner silently picks
+    # an arbitrary parent and downstream §3/§4 consumers would emit
+    # confidently-wrong fixes. Consumers guard on this set to route
+    # colliding sids to unresolved "ambiguous" Issues instead.
+    #
+    # Collision detection is PROJECT-BLIND: two session notes sharing a
+    # sid across different projects (re-imports, project-rename
+    # migrations) would otherwise have one collider filtered out by
+    # ``--project=foo`` and resurrect an arbitrary winner inside the
+    # filtered scan. ``_all_sids_seen`` therefore indexes every session
+    # note regardless of project; emission indices
+    # (``sessions_by_id`` / ``snapshots``) remain project-filtered.
+    _sid_collisions: set[str] = set()
+    _all_sids_seen: set[str] = set()
     snapshots: list[tuple[Path, dict, str]] = []
 
     # Stash the resolved vault root on each legacy-filename issue so
@@ -103,12 +108,22 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
         fm = _parse_fm(text)
         if not fm:
             continue
+        type_ = fm.get("type", "")
+        sid = fm.get("session_id", "") if type_ == "claude-session" else ""
+        # Project-blind collision detection (see block comment above).
+        if sid:
+            if sid in _all_sids_seen:
+                _sid_collisions.add(sid)
+            else:
+                _all_sids_seen.add(sid)
+        # Project-filtered emission indices.
         if project and fm.get("project", "").lower() != project.lower():
             continue
-        type_ = fm.get("type", "")
         if type_ == "claude-session":
-            sid = fm.get("session_id", "")
-            if sid:
+            # First-writer-wins: the winner is retained as the
+            # (unreliable) lookup target; consumers short-circuit via
+            # ``_sid_collisions`` before trusting it.
+            if sid and sid not in sessions_by_id:
                 sessions_by_id[sid] = p
         elif type_ == "claude-snapshot":
             snapshots.append((p, fm, text))
@@ -159,32 +174,73 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
         if "source_session_note" in fm and fm["source_session_note"]:
             continue
         sid = fm.get("session_id", "")
-        date = fm.get("date", "")
         proj = fm.get("project", "")
-        if not sid or not date or not proj:
+        if not sid or not proj:
+            missing = []
+            if not sid:
+                missing.append("session_id")
+            if not proj:
+                missing.append("project")
             issues.append(Issue(
                 check="snapshot-missing-backlink",
                 note_path=str(p),
                 project=proj,
                 current_source="(no source_session_note)",
                 proposed_source="",
-                reason="cannot compute parent stem (missing session_id/date/project)",
+                reason=f"cannot resolve parent (missing frontmatter: {', '.join(missing)})",
                 confidence=0.0,
                 extra={"unresolved": True},
             ))
             continue
-        parent_stem = f"{date}-{_slugify(proj)}-{_short_session_hash(sid)}"
-        parent_exists = (sess_dir / f"{parent_stem}.md").exists()
+        # Issue #81: if two session notes share this sid, we cannot name
+        # the authoritative parent. Emit an unresolved "ambiguous" Issue
+        # and skip the arbitrary winner lookup. The sid is included in the
+        # reason verbatim so operators can grep their vault for the
+        # offending session notes.
+        if sid in _sid_collisions:
+            issues.append(Issue(
+                check="snapshot-missing-backlink",
+                note_path=str(p),
+                project=proj,
+                current_source="(no source_session_note)",
+                proposed_source="",
+                reason=(
+                    f"ambiguous parent — multiple session notes share "
+                    f"session_id={sid!r}; resolve by deduping the colliding "
+                    f"session notes in the sessions folder"
+                ),
+                confidence=0.0,
+                extra={"unresolved": True},
+            ))
+            continue
+        parent_path = sessions_by_id.get(sid)
+        if parent_path is None:
+            # Orphan — no session note with matching session_id in the
+            # sessions folder (sessions_by_id is built from sess_dir only,
+            # non-recursive). Let a future snapshot-orphan check own this
+            # case; do NOT fabricate a wikilink from (date, slug,
+            # sid_hash) — that is exactly the bug #68 fixed.
+            issues.append(Issue(
+                check="snapshot-missing-backlink",
+                note_path=str(p),
+                project=proj,
+                current_source="(no source_session_note)",
+                proposed_source="",
+                reason=f"parent session not found — no session note with session_id={sid!r} in sessions folder",
+                confidence=0.0,
+                extra={"unresolved": True},
+            ))
+            continue
+        parent_stem = parent_path.stem
         issues.append(Issue(
             check="snapshot-missing-backlink",
             note_path=str(p),
             project=proj,
             current_source="(no source_session_note)",
             proposed_source=f'source_session_note: "[[{parent_stem}]]"',
-            reason=("parent session found" if parent_exists else
-                    "parent session not found — will warn only"),
-            confidence=0.95 if parent_exists else 0.3,
-            extra={"unresolved": not parent_exists, "parent_stem": parent_stem},
+            reason="parent session resolved via session_id index",
+            confidence=0.95,
+            extra={"unresolved": False, "parent_stem": parent_stem},
         ))
 
     # 4. session-missing-snapshots-list
@@ -194,6 +250,11 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
         if sid:
             snaps_by_sid.setdefault(sid, []).append(p.stem)
     for sid, stems in snaps_by_sid.items():
+        # Issue #81: colliding sids have no authoritative parent, so we
+        # cannot propose a snapshots: list against one of the two session
+        # notes without a 50/50 chance of being wrong.
+        if sid in _sid_collisions:
+            continue
         if sid not in sessions_by_id:
             continue
         sess_path = sessions_by_id[sid]

--- a/plugins/obsidian-brain/scripts/vault_doctor_checks/source_sessions.py
+++ b/plugins/obsidian-brain/scripts/vault_doctor_checks/source_sessions.py
@@ -2,15 +2,19 @@
 
 Detection strategy:
   For each insight-type note with a `source_session` frontmatter field,
-  read the note's file mtime as the "capture time." For each JSONL file
-  under ~/.claude/projects/*<project>/*.jsonl, determine its activity
-  window (first entry timestamp → file mtime). The correct source session
-  is the JSONL whose window contains the note's capture time. Flag as
-  stale whenever the note's current source_session does not match.
+  determine capture-time via an immutable-signal preference chain
+  (`created_at` ISO-8601 → `date` YYYY-MM-DD midday UTC → filename prefix
+  YYYY-MM-DD-... midday UTC → mtime as low-confidence last resort).
+  For each JSONL file under ~/.claude/projects/*<project>/*.jsonl,
+  determine its activity window (first entry timestamp → file mtime).
+  The correct source session is the JSONL whose window contains the
+  note's capture-time. Flag as stale whenever the note's current
+  source_session does not match.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import glob
 import json
 import os
@@ -68,19 +72,54 @@ def _safe_project_slug(project: str) -> str:
     return slug or "unknown"
 
 
-def _parse_frontmatter(text: str) -> dict:
-    """Parse a flat key: value YAML frontmatter block. Nested blocks ignored."""
+def _parse_frontmatter(text: str, source: str | None = None) -> dict:
+    """Parse a flat key: value YAML frontmatter block. Nested blocks ignored.
+
+    Flat-only by design — multiline scalars, folded YAML (``key:\\n  value``),
+    block sequences nested under a key, and other non-flat YAML constructs are
+    silently skipped. When a key without a same-line value is followed by an
+    indented continuation line that looks like folded YAML, a stderr warning
+    is emitted once per ``(file, key)`` within this parse (review SF5) so
+    operators can spot high-confidence signals being silently degraded to
+    mtime fallbacks. Note: dedup is per-call — the same folded key in two
+    different files (or two re-parses of the same file) will each warn.
+
+    Args:
+        text: full file contents (frontmatter must start at byte 0).
+        source: optional path/identifier surfaced in the SF5 warning so the
+            offending file is locatable in operator logs.
+    """
     m = _FRONT_RE.match(text)
     if not m:
         return {}
     out: dict = {}
-    for line in m.group(1).splitlines():
+    lines = m.group(1).splitlines()
+    folded_warned: set[str] = set()
+    for i, line in enumerate(lines):
         if not line or line.startswith(" ") or line.startswith("-"):
             continue  # skip list items and nested keys
         if ":" not in line:
             continue
         key, _, value = line.partition(":")
-        out[key.strip()] = value.strip().strip('"').strip("'")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if not value:
+            # Key with no same-line value. If the next line is indented,
+            # it's folded/multiline YAML — log once per (file, key) so the
+            # silent degradation is visible. Skip the key as before.
+            nxt = lines[i + 1] if (i + 1) < len(lines) else ""
+            if nxt and (nxt.startswith(" ") or nxt.startswith("\t")):
+                tag = f"{source or '?'}::{key}"
+                if tag not in folded_warned:
+                    folded_warned.add(tag)
+                    print(
+                        f"[vault_doctor] folded-YAML key skipped "
+                        f"(parser is flat-only): {key} "
+                        f"(file: {source or 'unknown'})",
+                        file=sys.stderr,
+                    )
+                continue
+        out[key] = value
     return out
 
 
@@ -94,6 +133,84 @@ def _parse_iso_ts(ts: str) -> float | None:
         return datetime.fromisoformat(ts).timestamp()
     except ValueError:
         return None
+
+
+def _parse_date_ts(date_str: str, hour: int = 0) -> float | None:
+    """Parse a YYYY-MM-DD date string to a POSIX timestamp at `hour`:00 UTC.
+
+    `hour=12` (midday) is used for the diagnostic reason text (the
+    capture_time printed in Issue.reason) and for created_at-style
+    point-in-window matching as a degraded fallback. It is NOT used by the
+    primary day-overlap matcher — that path calls _parse_date_ts(date, hour=0)
+    directly to compute day_start, and derives day_end as day_start + 86400.
+
+    `hour=0` (midnight) is used for calendar-day-overlap checks against a
+    JSONL window in Phase 1b and in _find_matching_session_by_day_overlap.
+    """
+    if not date_str:
+        return None
+    try:
+        d = datetime.strptime(date_str, "%Y-%m-%d").replace(
+            hour=hour, tzinfo=timezone.utc
+        )
+        return d.timestamp()
+    except ValueError:
+        return None
+
+
+def _parse_date_midpoint(date_str: str) -> float | None:
+    """Return the POSIX timestamp at 12:00 UTC of a YYYY-MM-DD date_str.
+
+    Used by _capture_time to convert day-precision signals (frontmatter
+    `date`, filename prefix) into a single capture-time anchor for the
+    diagnostic reason field. The day-overlap matcher uses _parse_date_ts
+    directly with hour=0; this helper is for point-anchor consumers.
+    """
+    return _parse_date_ts(date_str, hour=12)
+
+
+def _parse_date_start(date_str: str) -> float | None:
+    """Return the POSIX timestamp at 00:00 UTC of a YYYY-MM-DD date_str.
+
+    Currently unused in the production code path; retained as a
+    symmetric public helper in case future checks need a midnight anchor.
+    """
+    return _parse_date_ts(date_str, hour=0)
+
+
+# Filename prefix YYYY-MM-DD-...
+_FILENAME_DATE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-")
+
+
+def _capture_time(note_path: Path, fm: dict) -> tuple[float, float, str]:
+    """Return (POSIX_ts, confidence, signal_name) using immutable signals first.
+
+    Preference order:
+      1. fm['created_at'] ISO-8601                 → conf 1.0,  signal 'created_at'
+      2. fm['date'] YYYY-MM-DD (interpreted as     → conf 0.9,  signal 'date'
+         midpoint of UTC day)
+      3. filename prefix YYYY-MM-DD-...            → conf 0.85, signal 'filename'
+      4. os.path.getmtime() (last resort)          → conf 0.5,  signal 'mtime'
+      5. unreadable file                           → conf 0.0,  signal 'none'
+
+    Confidence is surfaced in the issue payload so the report can
+    distinguish high-signal matches from low-signal fallbacks.
+    """
+    # 1. created_at
+    if (ts := _parse_iso_ts(fm.get("created_at", ""))) is not None:
+        return (ts, 1.0, "created_at")
+    # 2. date (day-precision)
+    if (ts := _parse_date_midpoint(fm.get("date", ""))) is not None:
+        return (ts, 0.9, "date")
+    # 3. filename prefix
+    if (m := _FILENAME_DATE_RE.match(note_path.name)):
+        if (ts := _parse_date_midpoint(m.group(1))) is not None:
+            return (ts, 0.85, "filename")
+    # 4. mtime (last resort)
+    try:
+        return (os.path.getmtime(note_path), 0.5, "mtime")
+    except OSError:
+        return (0.0, 0.0, "none")
 
 
 def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
@@ -133,6 +250,14 @@ def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
                 file=sys.stderr,
             )
             return None
+        # SF6: parseable lines but no `timestamp` field — log the synthesized
+        # 1-hour window so a future schema variant can't silently produce
+        # confidently-wrong matches.
+        print(
+            f"[vault_doctor] JSONL has no timestamp fields; "
+            f"using synthetic 1h window: {jsonl_path}",
+            file=sys.stderr,
+        )
         first_ts = mtime - 3600
     return (first_ts, mtime)
 
@@ -176,22 +301,114 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     # same-mtime dirs pick the same winner across runs instead of depending
     # on glob order. Matches the (mtime, path) pattern used for JSONL
     # selection elsewhere in the fast path.
-    return Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
+    winner = Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
+    if len(viable) > 1:
+        # SF8: silent picker on collision is invisible to operators when a
+        # path-encoding variant masks a real cross-project ambiguity. Log the
+        # candidates + winner so it's auditable.
+        print(
+            f"[vault_doctor] multiple project dirs matched {project}: "
+            f"{[m for m, _ in viable]}; using {winner}",
+            file=sys.stderr,
+        )
+    return winner
 
 
-def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
-    """Map session_id → {path, basename, date} for a project's session notes."""
+def _find_jsonl_anywhere(
+    sid: str, cache: dict[str, Path | None] | None = None
+) -> Path | None:
+    """Locate ~/.claude/projects/*/<sid>.jsonl across all CC project dirs.
+
+    UUIDs are globally unique, so this is safe even though it ignores the
+    project-name index. Returns the first match (deterministic via sorted)
+    or None.
+
+    The project segment uses ``*`` so CC's underscore-to-hyphen slug
+    normalization is irrelevant here — there's no need to normalize the
+    input project name (the SID alone is sufficient to disambiguate).
+    """
+    if cache is not None and sid in cache:
+        return cache[sid]
+    home = os.environ.get("HOME", os.path.expanduser("~"))
+    pattern = os.path.join(home, ".claude", "projects", "*", f"{sid}.jsonl")
+    matches = sorted(glob.glob(pattern))
+    result = Path(matches[0]) if matches else None
+    if cache is not None:
+        cache[sid] = result
+    return result
+
+
+def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
+    """Map session_id → {path, basename, date, project} across ALL projects.
+
+    Used by Phase 1b's UUID-first lookup to handle the case where a note's
+    declared `project:` doesn't match its actual source session note's
+    `project:` (e.g., insight written from main repo's cwd while the
+    session ran in a worktree). The session_id is globally unique, so
+    cross-project lookup is safe.
+
+    Iterates entries in sorted order so the winner is deterministic across
+    runs (Copilot R5). When two session notes share the same session_id
+    (a known possible vault state — typically a vault-import collision or
+    a rename gone wrong), warn to stderr instead of silently overwriting.
+    """
     out: dict[str, dict] = {}
     if not sessions_dir.is_dir():
         return out
-    for entry in sessions_dir.iterdir():
+    for entry in sorted(sessions_dir.iterdir()):
         if not entry.name.endswith(".md"):
             continue
         try:
             text = entry.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        fm = _parse_frontmatter(text)
+        fm = _parse_frontmatter(text, source=str(entry))
+        if not fm:
+            if text.startswith("---"):
+                print(
+                    f"[vault_doctor] malformed frontmatter, skipped: {entry}",
+                    file=sys.stderr,
+                )
+            continue
+        sid = fm.get("session_id", "")
+        if not sid:
+            continue
+        if fm.get("type") != "claude-session":
+            continue  # skip claude-snapshot — same UUID, not the canonical session
+        if sid in out:
+            print(
+                f"[vault_doctor] duplicate session_id {sid[:8]} across "
+                f"{out[sid]['path'].name} and {entry.name} — keeping first "
+                f"(sorted-order winner); rename one to disambiguate",
+                file=sys.stderr,
+            )
+            continue
+        out[sid] = {
+            "path": entry,
+            "basename": entry.name[:-3],
+            "date": fm.get("date", ""),
+            "project": fm.get("project", ""),
+        }
+    return out
+
+
+def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
+    """Map session_id → {path, basename, date} for a project's session notes.
+
+    Iterates in sorted order for a deterministic duplicate-SID winner; warns
+    on collisions (Copilot R5; mirrors _list_all_session_notes).
+    """
+    out: dict[str, dict] = {}
+    if not sessions_dir.is_dir():
+        return out
+    for entry in sorted(sessions_dir.iterdir()):
+        if not entry.name.endswith(".md"):
+            continue
+        try:
+            text = entry.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        fm = _parse_frontmatter(text, source=str(entry))
         if not fm and text.startswith("---"):
             print(
                 f"[vault_doctor] malformed frontmatter, skipped: {entry}",
@@ -202,6 +419,16 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
             continue
         sid = fm.get("session_id", "")
         if not sid:
+            continue
+        if fm.get("type") != "claude-session":
+            continue  # skip claude-snapshot — same UUID, not the canonical session
+        if sid in out:
+            print(
+                f"[vault_doctor] duplicate session_id {sid[:8]} across "
+                f"{out[sid]['path'].name} and {entry.name} — keeping first "
+                f"(sorted-order winner); rename one to disambiguate",
+                file=sys.stderr,
+            )
             continue
         out[sid] = {
             "path": entry,
@@ -243,6 +470,47 @@ def _find_matching_session(
     return {**session_note_index[best_sid], "sid": best_sid}
 
 
+def _find_matching_session_by_day_overlap(
+    date_str: str,
+    jsonl_dir: Path | None,
+    session_note_index: dict[str, dict],
+) -> dict | None:
+    """Return the session note dict whose JSONL window has the largest
+    overlap with the UTC calendar day of date_str.
+
+    Used for day-precision signals (`date`, `filename`) where a single
+    capture_time anchor (e.g., noon UTC) excludes morning-only or
+    evening-only sessions. Tie-break: largest overlap, then latest
+    first_ts (mirrors point-match behavior).
+    """
+    if not jsonl_dir or not jsonl_dir.is_dir():
+        return None
+    day_start = _parse_date_ts(date_str, hour=0)
+    if day_start is None:
+        return None
+    day_end = day_start + 86400
+    best_sid: str | None = None
+    best_overlap: float = 0
+    best_first_ts: float = 0
+    for jsonl in sorted(jsonl_dir.glob("*.jsonl")):
+        sid = jsonl.stem
+        if sid not in session_note_index:
+            continue
+        window = _jsonl_window(str(jsonl))
+        if window is None:
+            continue
+        first_ts, last_ts = window
+        overlap = max(0.0, min(day_end, last_ts) - max(day_start, first_ts))
+        if overlap <= 0:
+            continue
+        # Pick largest overlap; tie-break by latest first_ts
+        if (overlap > best_overlap) or (overlap == best_overlap and first_ts > best_first_ts):
+            best_sid, best_overlap, best_first_ts = sid, overlap, first_ts
+    if best_sid is None:
+        return None
+    return {**session_note_index[best_sid], "sid": best_sid}
+
+
 def scan(
     vault_path: str,
     sessions_folder: str,
@@ -266,6 +534,10 @@ def scan(
     issues: list[Issue] = []
     session_index_cache: dict[str, dict[str, dict]] = {}
     jsonl_dir_cache: dict[str, Path | None] = {}
+    global_sid_index: dict[str, dict] | None = None  # built lazily on first need
+    # Per-scan memoization for _find_jsonl_anywhere — avoids O(N_notes * N_projects)
+    # filesystem walks when many notes hit the worktree-suffixed project fallback.
+    jsonl_anywhere_cache: dict[str, Path | None] = {}
 
     for folder in scan_folders:
         folder_path = vault / folder
@@ -284,7 +556,7 @@ def scan(
                 text = note.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            fm = _parse_frontmatter(text)
+            fm = _parse_frontmatter(text, source=str(note))
             if "source_session" not in fm:
                 continue  # non-source-session note type (e.g., standups with source_notes[])
             note_project = fm.get("project", "")
@@ -292,6 +564,12 @@ def scan(
                 continue
             if project and note_project.replace("_", "-") != project.replace("_", "-"):
                 continue
+
+            # Capture-time for JSONL-window matching uses immutable signals.
+            # mtime above is only the --days cutoff, not the matcher input.
+            capture_time, capture_conf, capture_signal = _capture_time(note, fm)
+            if capture_conf == 0.0:
+                continue  # corrupt note — no usable signal
 
             # Normalize cache key so personal_ws and personal-ws share index
             cache_key = note_project.replace("_", "-")
@@ -317,12 +595,142 @@ def scan(
             else:
                 current_source_display = ""
 
-            match = _find_matching_session(mtime, jsonl_dir, idx)
+            # Phase 1b — UUID-first authoritative signal:
+            # if current source's UUID resolves to ANY session note in the
+            # vault (cross-project, since worktree-launched skills may write
+            # `project:` from main-repo cwd while their source session ran
+            # in a worktree), check whether the JSONL window overlaps the
+            # note's calendar day. If yes, the UUID is correct; only the
+            # basename in source_session_note may need updating.
+            #
+            # Only applies for day-precision signals (date, filename, mtime).
+            # When created_at provides a precise sub-day timestamp the matcher
+            # has enough resolution; let it run.
+            if current_sid and capture_signal != "created_at":
+                if global_sid_index is None:
+                    global_sid_index = _list_all_session_notes(sessions_dir)
+                if current_sid in global_sid_index:
+                    sess = global_sid_index[current_sid]
+                    sess_project = sess.get("project", "")
+                    sess_jsonl_dir = (
+                        _jsonl_dir_for_project(sess_project) if sess_project else None
+                    )
+                    note_date = fm.get("date", "")
+                    if not note_date:
+                        fn_match = _FILENAME_DATE_RE.match(note.name)
+                        note_date = fn_match.group(1) if fn_match else ""
+                    day_start = _parse_date_ts(note_date, hour=0) if note_date else None
+                    window = None
+                    if sess_jsonl_dir is not None:
+                        jsonl_path = sess_jsonl_dir / f"{current_sid}.jsonl"
+                        if jsonl_path.exists():
+                            window = _jsonl_window(str(jsonl_path))
+                    if window is None:
+                        # I4 fix: when project-dir lookup misses (e.g., worktree-
+                        # suffixed project name in the session note), try global
+                        # JSONL search by UUID.
+                        fallback_path = _find_jsonl_anywhere(
+                            current_sid, cache=jsonl_anywhere_cache
+                        )
+                        if fallback_path is not None:
+                            window = _jsonl_window(str(fallback_path))
+                    if day_start is not None and window is not None:
+                        day_end = day_start + 86400
+                        first_ts, last_ts = window
+                        if first_ts < day_end and last_ts > day_start:
+                            # UUID resolves AND window overlaps note's day → UUID is correct.
+                            # Now check if source_session_note basename is stale.
+                            actual_basename = sess["basename"]
+                            if (
+                                current_src_basename
+                                and current_src_basename != actual_basename
+                            ):
+                                # Basename mismatch (e.g., un-truncated worktree slug
+                                # vs truncated actual filename). Propose basename-only
+                                # repair; UUID stays the same.
+                                issues.append(
+                                    Issue(
+                                        check=NAME,
+                                        note_path=str(note),
+                                        project=note_project,
+                                        current_source=current_source_display,
+                                        proposed_source=f"[[{actual_basename}]]",
+                                        reason=(
+                                            f"source_session UUID {current_sid[:8]} resolves "
+                                            f"correctly but source_session_note basename is "
+                                            f"stale (expected '{actual_basename}', got "
+                                            f"'{current_src_basename}')"
+                                        ),
+                                        confidence=0.99,
+                                        extra={
+                                            "proposed_sid": current_sid,
+                                            "basename_only": True,
+                                            "capture_signal": capture_signal,
+                                            "capture_confidence": capture_conf,
+                                        },
+                                    )
+                                )
+                            continue  # UUID is authoritative either way; skip matcher
+                else:
+                    # UUID not in session-note index — but a real JSONL may
+                    # still exist (SessionEnd hook missed; see issue #98).
+                    # Emit an unresolved diagnostic Issue so operators can see
+                    # the coverage gap; UUID is authoritative, so don't propose
+                    # a different-session rewrite.
+                    jsonl_path = _find_jsonl_anywhere(
+                        current_sid, cache=jsonl_anywhere_cache
+                    )
+                    if jsonl_path is not None:
+                        issues.append(
+                            Issue(
+                                check=NAME,
+                                note_path=str(note),
+                                project=note_project,
+                                current_source=current_source_display,
+                                proposed_source="",
+                                reason=(
+                                    f"source UUID {current_sid[:8]} has a JSONL "
+                                    f"but no session note in the vault "
+                                    f"(see issue #98 for coverage-gap detector)"
+                                ),
+                                confidence=0.0,
+                                extra={
+                                    "unresolved": True,
+                                    "missing_session_note": True,
+                                    "jsonl_path": str(jsonl_path),
+                                    "capture_signal": capture_signal,
+                                    "capture_confidence": capture_conf,
+                                },
+                            )
+                        )
+                        continue  # UUID is authoritative; skip matcher
+
+            # Day-precision signals: match by greatest overlap with UTC calendar day.
+            # Sub-day precision (created_at): match by point-in-window.
+            # Track which matcher actually ran so the reason text below
+            # describes the right contract (Copilot R4: mtime with no date or
+            # filename prefix falls through to point-in-window matching).
+            note_date_for_match = ""
+            used_day_overlap = False
+            if capture_signal == "created_at":
+                match = _find_matching_session(capture_time, jsonl_dir, idx)
+            else:
+                note_date_for_match = fm.get("date", "")
+                if not note_date_for_match:
+                    fn_match = _FILENAME_DATE_RE.match(note.name)
+                    note_date_for_match = fn_match.group(1) if fn_match else ""
+                if note_date_for_match:
+                    match = _find_matching_session_by_day_overlap(
+                        note_date_for_match, jsonl_dir, idx
+                    )
+                    used_day_overlap = True
+                else:
+                    match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
-                # No JSONL window contains this mtime. Flag as unresolved ONLY if
-                # the current source doesn't resolve to any known session note — that
-                # way we don't get false positives on notes whose current source is
-                # correct but just doesn't have a matching JSONL window locally.
+                # No JSONL window contains the note's capture_time. Flag as unresolved
+                # ONLY if the current source doesn't resolve to any known session note
+                # — that way we don't get false positives on notes whose current source
+                # is correct but just doesn't have a matching JSONL window locally.
                 if current_sid not in idx:
                     issues.append(
                         Issue(
@@ -331,9 +739,16 @@ def scan(
                             project=note_project,
                             current_source=current_source_display,
                             proposed_source="",
-                            reason="no session window contains note mtime",
+                            reason=(
+                                f"no session window contains note capture_time"
+                                f" (signal={capture_signal}, conf={capture_conf})"
+                            ),
                             confidence=0.0,
-                            extra={"unresolved": True},
+                            extra={
+                                "unresolved": True,
+                                "capture_signal": capture_signal,
+                                "capture_confidence": capture_conf,
+                            },
                         )
                     )
                 continue
@@ -341,6 +756,35 @@ def scan(
             if match["sid"] == current_sid:
                 continue  # correct
 
+            # Cap confidence on date-only signals: day-precision matching can still
+            # be ambiguous on multi-session days because multiple windows may overlap
+            # the same UTC calendar day. `created_at` is the only signal precise
+            # enough for high confidence.
+            if capture_signal == "created_at":
+                proposed_conf = 0.95
+            elif capture_signal == "mtime":
+                proposed_conf = 0.3  # below convergence floor; never auto-apply
+            else:
+                proposed_conf = 0.6
+            # Build reason text matching the matcher actually used (Copilot R4):
+            # day-overlap → describe calendar-day match; point-in-window →
+            # describe capture_time match. mtime with no date/filename takes
+            # the point-in-window branch even though signal != created_at.
+            if used_day_overlap:
+                reason = (
+                    f"note calendar day {note_date_for_match}"
+                    f" (signal={capture_signal}, conf={capture_conf})"
+                    f" overlaps session {match['sid'][:8]} window most, "
+                    f"not current source {current_sid[:8]}"
+                )
+            else:
+                reason = (
+                    f"note capture_time "
+                    f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
+                    f" (signal={capture_signal}, conf={capture_conf})"
+                    f" matches session {match['sid'][:8]} window, "
+                    f"not current source {current_sid[:8]}"
+                )
             issues.append(
                 Issue(
                     check=NAME,
@@ -348,14 +792,54 @@ def scan(
                     project=note_project,
                     current_source=current_source_display,
                     proposed_source=f"[[{match['basename']}]]",
-                    reason=(
-                        f"note mtime {datetime.fromtimestamp(mtime, timezone.utc).isoformat(timespec='seconds')}"
-                        f" matches session {match['sid'][:8]} window, not current source {current_sid[:8]}"
-                    ),
-                    confidence=0.95,
-                    extra={"proposed_sid": match["sid"]},
+                    reason=reason,
+                    confidence=proposed_conf,
+                    extra={
+                        "proposed_sid": match["sid"],
+                        "capture_signal": capture_signal,
+                        "capture_confidence": capture_conf,
+                    },
                 )
             )
+
+    # Convergence guard: if multiple flags in a project propose the same
+    # target session, the date-window heuristic has structurally collapsed
+    # across a multi-session day. Lower confidence and tag for operator review.
+    #
+    # Restrict the guard to day-precision signals (date/filename/mtime) —
+    # `created_at` matches use point-in-window with sub-day precision, so two
+    # legitimate stale notes from the same session sharing a proposal target
+    # is just normal cluster behavior, not heuristic collapse (Copilot R4-2).
+    from collections import Counter
+    _DAY_PRECISION_SIGNALS = {"date", "filename", "mtime"}
+    targets = Counter(
+        (i.project, i.extra.get("proposed_sid", ""))
+        for i in issues
+        if (
+            i.extra.get("proposed_sid")
+            and not i.extra.get("basename_only")
+            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
+        )
+    )
+    issues = [
+        dataclasses.replace(
+            i,
+            confidence=min(i.confidence, 0.4),
+            extra={
+                **i.extra,
+                "convergence_warning": True,
+                "convergence_count": targets[(i.project, i.extra.get("proposed_sid", ""))],
+            },
+        )
+        if (
+            not i.extra.get("basename_only")
+            and i.extra.get("proposed_sid")
+            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
+            and targets[(i.project, i.extra.get("proposed_sid", ""))] >= 2
+        )
+        else i
+        for i in issues
+    ]
 
     return issues
 
@@ -468,8 +952,11 @@ def apply(issues, backup_root) -> list[Result]:
             continue
 
         # Capture original stat so we can preserve mtime across the rewrite.
-        # scan() uses note mtime as capture_time for JSONL window matching —
-        # updating mtime on apply would cause re-runs to re-flag fixed notes.
+        # scan() uses mtime for the --days cutoff filter. If apply() let the
+        # rewrite bump mtime to now, repaired notes would re-enter the scan
+        # window every run (and could be re-flagged via mtime-fallback signal
+        # if their immutable signals are ever lost). Preserving the original
+        # mtime keeps the rewrite invisible to the cutoff filter.
         try:
             original_stat = os.stat(issue.note_path)
         except OSError as exc:
@@ -524,7 +1011,12 @@ def apply(issues, backup_root) -> list[Result]:
                     backup_path=str(backup_path),
                 )
             )
-        except Exception as exc:  # per-issue isolation; don't abort the loop
+        except (OSError, ValueError, UnicodeDecodeError) as exc:
+            # SF9: narrowed from bare `except Exception` so MemoryError,
+            # RecursionError, and other non-I/O failures propagate instead
+            # of being misreported as ordinary per-issue rewrite failures.
+            # KeyboardInterrupt and SystemExit are BaseException, not Exception,
+            # and were never caught by the original handler.
             results.append(
                 Result(
                     check=NAME,

--- a/plugins/obsidian-brain/skills/compress/SKILL.md
+++ b/plugins/obsidian-brain/skills/compress/SKILL.md
@@ -73,9 +73,12 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os, json
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from vault_index import ensure_index, search_vault
-from obsidian_utils import load_config
 try:
+    from vault_index import ensure_index, search_vault
+    from obsidian_utils import load_config
+    # Pure predicate: top rank must pass absolute-strength gate AND |top|-|#2| delta gate.
+    # MIN_RANK_DELTA tuned against scripts/compress_rank_gap_corpus.json (issue #45).
+    from compress_guard import is_high_confidence_match
     c = load_config()
     vp = c["vault_path"]
     folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
@@ -84,17 +87,14 @@ try:
     results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
     # Sort combined results by rank (most negative = best match)
     results.sort(key=lambda r: r["rank"])
-    # Apply high-confidence threshold: top result must have rank <= -5.0
-    # AND must be significantly ahead of #2 (at least 1.5x better rank)
-    if results:
+    if is_high_confidence_match(results):
         top = results[0]
-        rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
-        if top["rank"] <= -5.0 and rank_gap_ok:
-            print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
-        else:
-            print(json.dumps({"match": False}))
+        print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
     else:
         print(json.dumps({"match": False}))
+except ImportError as e:
+    print(f"Warning: plugin hooks are out of date or missing ({e}) — run /dev-test install", file=sys.stderr)
+    print(json.dumps({"match": False}))
 except Exception as e:
     print(f"Warning: could not search vault index: {e}", file=sys.stderr)
     print(json.dumps({"match": False}))
@@ -290,6 +290,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-insight
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -307,6 +308,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/plugins/obsidian-brain/skills/decide/SKILL.md
+++ b/plugins/obsidian-brain/skills/decide/SKILL.md
@@ -102,6 +102,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-decision
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -142,6 +143,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/plugins/obsidian-brain/skills/error-log/SKILL.md
+++ b/plugins/obsidian-brain/skills/error-log/SKILL.md
@@ -100,6 +100,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-error-fix
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -131,6 +132,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/plugins/obsidian-brain/skills/recall/SKILL.md
+++ b/plugins/obsidian-brain/skills/recall/SKILL.md
@@ -234,14 +234,23 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 3. **Present candidates to user.** Branch by N (number of candidates):
 
-   **N ≤ 4 — native multi-select picker:**
+   **2 ≤ N ≤ 3 — native multi-select picker:**
 
-   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate:
+   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate, then append exactly one sentinel option (described below). `AskUserQuestion` enforces `options: { minItems: 2, maxItems: 4 }`, so this branch covers N ∈ {2, 3} real candidates (plus the sentinel = 3 or 4 total options). N=1 routes to the text fallback below because minItems=2 would be violated; N=4+ routes to the text fallback because N=4 real + 1 sentinel = 5 options, which exceeds maxItems=4.
+
+   Per-candidate option:
 
    - `label`: first ~40 characters of the candidate's `text` field, ellipsized with `…` if truncated. No paraphrase — take a prefix of the verbatim text.
    - `description`: `<basename(file)>:<line> — "<full verbatim candidate.text>" — Evidence: <short evidence snippet>`
 
-   Example shape:
+   Sentinel option (always appended last):
+
+   - `label` (exact string, treat as the sentinel identity key): `Skip all — don't check off anything`
+   - `description`: `Leave all open items as-is`
+
+   The sentinel makes "defer everything" a visible, selectable choice rather than an empty-submit convention. Step 5 will compare each selected option's `label` against the exact sentinel string above and drop any match before Read-verify.
+
+   Example shape (N=2 real candidates + sentinel = 3 options, within the `maxItems: 4` cap):
 
    ```
    AskUserQuestion({
@@ -254,17 +263,33 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
            label: "File #69: Investigate /recall parallel subpro…",
            description: "2026-04-20-obsidian-brain-7769.md:42 — \"File #69: Investigate /recall parallel subprocess dispatch sequentiality in Claude Code harness\" — Evidence: \"...shipped v2.4.0 ...completing issue #69...\""
          },
-         ...
+         {
+           label: "Another item…",
+           description: "..."
+         },
+         {
+           label: "Skip all — don't check off anything",
+           description: "Leave all open items as-is"
+         }
        ]
      }]
    })
    ```
 
-   Record the user's selected options. Empty selection → treat as `none`.
+   Record the user's selected options, then normalize in this exact order:
 
-   **N > 4 — verbatim text fallback:**
+   1. **Filter out the sentinel** by dropping any selected option whose `label` equals the exact string `Skip all — don't check off anything`.
+   2. **If the filtered list is empty** (whether the pre-filter selection was empty *or* contained only the sentinel), treat as `none` → skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
+   3. **Otherwise** pass the filtered list (real candidates only) to Step 5.
 
-   Print:
+   **N == 1 or N ≥ 4 — verbatim text fallback:**
+
+   Print one numbered entry per candidate using the template below, with the `<CONFIRM_EXAMPLE>` placeholder replaced per N:
+
+   - N == 1 → `(e.g. `1` or `none`)`
+   - N ≥ 4 → `(e.g. `1` or `1,2` or `all` or `none`)`
+
+   Template (repeat the numbered block for each candidate):
 
    ```
    I noticed these open items may now be done:
@@ -275,19 +300,20 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    2. ...
 
-   Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
+   Confirm checkoff? <CONFIRM_EXAMPLE>
    ```
 
    The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block using the exact `candidate.text` content (no paraphrase, no ellipsis). Step 5's match rule then compares this text against the file line after normalizing the file side (strip leading whitespace, `- [ ] ` prefix, and trailing whitespace/newline) — so the presented text is what matches after normalization, not byte-for-byte against raw file bytes.
 
-4. **Wait for user response** (N > 4 branch only — the N ≤ 4 branch returns from `AskUserQuestion`). Parse the response:
+4. **Wait for user response** (text-fallback branch only — the `2 ≤ N ≤ 3` picker branch already returned a filtered list from the normalization steps above). Parse the response:
    - `none` or empty → skip the remaining checkoff sub-steps (5–7) and proceed directly to the "Show load manifest" block at the end of Step 4
    - `all` → check off all candidates
-   - Comma-separated numbers (e.g. `1,3`) → check off only those
-
-   **N ≤ 4 branch:** if the user's `AskUserQuestion` selection is empty, treat it the same way — skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
+   - Comma-separated numbers (e.g. `1,3`) → check off the candidates at those 1-indexed positions (for N=1, `1` checks off the single candidate)
+   - **Ambiguous or invalid input** — any index outside `1..N`, non-numeric tokens (e.g. `yes`, `y`), or mixed garbage: re-prompt exactly once with `I didn't understand "<input>". Reply with \`none\`, \`all\`, or a comma-separated list of numbers in 1..<N>.` On the second ambiguous reply, treat as `none` and print `Treating "<input>" as none — no items checked off.` so the fallback surfaces explicitly rather than silently defaulting.
 
 5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
+
+   **5-pre-sentinel. Sentinel-leak guard:** before the per-candidate loop, assert that no entry's `text` equals the exact sentinel string `Skip all — don't check off anything`. If one slipped through the Step 4 normalization, abort Step 5 entirely, emit `⚠️  Internal: Skip-all sentinel leaked into checkoff list — deferring all items.`, and proceed to the "Show load manifest" block. This surfaces filter bugs as diagnostic output instead of trying to Read a label-string as a file path.
 
    **5-pre. Within-batch dedup:** if the confirmed candidate list contains two entries with the same `(file, line)`, keep only the first and drop the rest automatically — they are scan duplicates, not drift. Do not emit per-duplicate warnings or treat them as skips. If any duplicates were removed, print this one-line informational message: `De-duplicated K within-batch candidate(s).`
 

--- a/plugins/obsidian-brain/skills/retro/SKILL.md
+++ b/plugins/obsidian-brain/skills/retro/SKILL.md
@@ -121,6 +121,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-retro
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -146,6 +147,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived from Step 5
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink from the retro to its source session

--- a/plugins/obsidian-brain/skills/vault-doctor/SKILL.md
+++ b/plugins/obsidian-brain/skills/vault-doctor/SKILL.md
@@ -81,7 +81,25 @@ If exit code is `3`, surface the stderr message directly to the user and stop.
 
 ### Step 3 — Present the report to the user
 
-Parse the JSON and present a grouped-by-project table. Example:
+Parse the JSON and present a grouped-by-project table.
+
+For each issue, after the `proposed:` line (when present), render a
+`signal: <capture_signal> (conf <capture_confidence>)` line. The values
+come from the top-level `capture_signal` and `capture_confidence` fields
+in the JSON payload (not from `extra.*`). `capture_confidence` reports
+how reliable the capture-time *signal* is (created_at=1.0, date=0.9,
+filename=0.85, mtime=0.5); the issue's top-level `confidence` field
+reports the *rewrite-proposal* confidence (created_at=0.95, mtime=0.3,
+otherwise 0.6) that gates `--apply --min-confidence`. The two are
+distinct — render `capture_confidence` here so heuristic-fall cases
+are visible (e.g., `signal=mtime conf=0.5` indicates no immutable
+signal was available — the operator should sample a few flagged
+notes before running `fix`). For
+unresolved issues with no `proposed:` line, render `signal:` after `reason:`.
+When `convergence_warning` is `true` in the issue, prefix the issue line
+with `[CONVERGED <N> flags]` where `N` is `convergence_count`.
+
+Example:
 
 ```
 vault_doctor report — 3 issue(s) across 1 check(s)
@@ -92,13 +110,15 @@ vault_doctor report — 3 issue(s) across 1 check(s)
 [FAIL] 2026-04-10-recall-profiling.md
   current:  [[2026-04-09-obsidian-brain-abcd]]
   proposed: [[2026-04-10-obsidian-brain-ef01]]
-  reason:   note mtime 2026-04-10T14:22 matches session ef010000 window...
+  signal:   date (conf 0.9)
+  reason:   note calendar day 2026-04-10 (signal=date, conf=0.9) overlaps session ef010000 window most, not current source abcd0000
 
 ### Project: tiny-vacation-agent (1 issue)
 [FAIL] 2026-04-11-enrichment-scope.md
   current:  [[2026-04-10-tiny-vacation-agent-aaaa]]
   proposed: [[2026-04-11-tiny-vacation-agent-bbbb]]
-  reason:   note mtime 2026-04-11T09:15 matches session bbbb0000 window...
+  signal:   created_at (conf 1.0)
+  reason:   note capture_time 2026-04-11T09:15:00+00:00 (signal=created_at, conf=1.0) matches session bbbb0000 window, not current source aaaa0000
 ```
 
 Use `[FAIL]` for actionable issues (those with a proposed fix) and `[WARN]` for unresolved ones (those the check could not auto-repair). Always include a one-line summary at the top with the total count.

--- a/plugins/obsidian-brain/templates/decision.md
+++ b/plugins/obsidian-brain/templates/decision.md
@@ -1,6 +1,7 @@
 ---
 type: claude-decision
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/plugins/obsidian-brain/templates/error-fix.md
+++ b/plugins/obsidian-brain/templates/error-fix.md
@@ -1,6 +1,7 @@
 ---
 type: claude-error-fix
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/plugins/obsidian-brain/templates/insight.md
+++ b/plugins/obsidian-brain/templates/insight.md
@@ -1,6 +1,7 @@
 ---
 type: claude-insight
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/plugins/obsidian-brain/tests/test_compress_rank_gap.py
+++ b/plugins/obsidian-brain/tests/test_compress_rank_gap.py
@@ -1,0 +1,118 @@
+"""Tests for hooks/compress_guard.py — /compress Step 3.5 rank-gap predicate.
+
+Covers boundary cases for `is_high_confidence_match()`, the pure predicate
+extracted from /compress SKILL.md Step 3.5. The helper is imported
+directly — no FTS5 fixture needed since the predicate takes a pre-sorted
+results list.
+"""
+
+from compress_guard import (
+    MIN_RANK_DELTA,
+    MIN_RANK_STRENGTH,
+    is_high_confidence_match,
+)
+
+
+def test_empty_results_rejects():
+    assert is_high_confidence_match([]) is False
+
+
+def test_equal_ranks_rejects():
+    """Delta = 0 when top and runner-up have identical ranks.
+
+    FTS5 can produce identical rank values for near-identical notes. The
+    strict '>' delta gate rejects (0 is never > any positive MIN_RANK_DELTA),
+    so the guard correctly asks the user to choose rather than auto-picking.
+    """
+    results = [{"rank": -10.0}, {"rank": -10.0}]
+    assert is_high_confidence_match(results) is False
+
+
+def test_single_result_matches_when_rank_strong():
+    # rank -10 is stronger than min_strength -5.0
+    assert is_high_confidence_match([{"rank": -10.0}]) is True
+
+
+def test_single_result_rejects_when_rank_weak():
+    # rank -3 is weaker than min_strength -5.0
+    assert is_high_confidence_match([{"rank": -3.0}]) is False
+
+
+def test_delta_above_threshold_matches():
+    # delta = |−29| − |−20| = 9, above default MIN_RANK_DELTA
+    results = [{"rank": -29.0}, {"rank": -20.0}]
+    assert is_high_confidence_match(results) is True
+
+
+def test_delta_below_threshold_rejects():
+    # delta ≈ 0.1 (|-29| - |-28.9| = 0.1000...142 due to IEEE 754);
+    # below the current THRESHOLD_GRID minimum of 0.25, so this case
+    # rejects at every grid-selectable MIN_RANK_DELTA.
+    results = [{"rank": -29.0}, {"rank": -28.9}]
+    assert is_high_confidence_match(results) is False
+
+
+def test_issue_45_repro_case():
+    """Executable form of the issue #45 bug definition.
+
+    Real ranks from the vault: top -29.46, runner-up -24.71, delta 4.75.
+    Must resolve True under the shipped MIN_RANK_DELTA — a failing
+    assertion here means the fix did not land. The shipped constant
+    must be strictly less than 4.75.
+    """
+    results = [{"rank": -29.46}, {"rank": -24.71}]
+    assert is_high_confidence_match(results) is True
+
+
+def test_weak_top_rank_rejects():
+    # List is sorted most-negative first (predicate's documented contract):
+    # -4.0 is the "top" at index 0, -3.0 is the runner-up at index 1. Top
+    # rank -4 still fails the strength gate (-4 > -5). The strength gate
+    # fires before the delta gate is evaluated — no strong #2 is needed
+    # to prove the point.
+    results = [{"rank": -4.0}, {"rank": -3.0}]
+    assert is_high_confidence_match(results) is False
+
+
+def test_delta_at_threshold_boundary_rejects():
+    """Strict > comparison: delta exactly at threshold must reject.
+
+    Predicate uses `delta > min_delta`, not `>=`. This test locks that
+    semantic so a future tuning change to a different MIN_RANK_DELTA
+    value still correctly rejects the at-threshold case.
+    Guards against an off-by-one drift toward `>=`.
+    """
+    # delta = |−29| − |−28.75| = 0.25, exactly equals default MIN_RANK_DELTA (0.25) → reject.
+    # Input values are multiples of 0.25, so they're exact binary fractions (no IEEE 754
+    # rounding); this makes the at-threshold equality check reliable. Future boundary tests
+    # should pick similarly-exact inputs rather than (say) 0.1, which is not exactly representable.
+    results = [{"rank": -29.0}, {"rank": -28.75}]
+    assert is_high_confidence_match(results) is False
+    # With a custom min_delta=0.15, same input has delta 0.25 > 0.15 → accept
+    assert is_high_confidence_match(results, min_delta=0.15) is True
+
+
+def test_custom_thresholds_respected():
+    # Sub-test 1: strength gate only (single result, delta gate bypassed)
+    results_single = [{"rank": -8.0}]
+    assert is_high_confidence_match(results_single) is True  # -8 <= default -5.0
+    assert (
+        is_high_confidence_match(results_single, min_strength=-10.0) is False
+    )  # -8 > -10 fails custom strength gate
+
+    # Sub-test 2: delta gate (two results; strength gate passes for both calls)
+    results_pair = [{"rank": -8.0}, {"rank": -7.9}]
+    assert is_high_confidence_match(results_pair) is False  # delta 0.1 below default 0.25
+    assert (
+        is_high_confidence_match(results_pair, min_delta=0.05) is True
+    )  # delta 0.1 above custom min_delta=0.05
+
+
+def test_constants_are_exposed():
+    # Import-level contract: callers can reference the defaults.
+    assert isinstance(MIN_RANK_STRENGTH, float)
+    assert isinstance(MIN_RANK_DELTA, float)
+    assert MIN_RANK_STRENGTH <= 0.0
+    assert MIN_RANK_DELTA > 0.0
+    # Hard constraint from issue #45 — fix is not complete without this.
+    assert MIN_RANK_DELTA < 4.75

--- a/plugins/obsidian-brain/tests/test_get_session_context.py
+++ b/plugins/obsidian-brain/tests/test_get_session_context.py
@@ -1,0 +1,901 @@
+# tests/test_get_session_context.py
+"""Tests for first-seen-date marker, hash-resolver, and basename invariants
+introduced for obsidian-brain#101 (subsumes #86)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import obsidian_utils
+
+
+def _unique_sid() -> str:
+    return f"test-sid-{uuid.uuid4().hex}"
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect `~/.claude/obsidian-brain/sessions/` into tmp_path so marker
+    writes do not pollute the real user directory across tests."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield tmp_path
+
+
+def test_first_seen_date_lazy_writes_and_returns_today(isolated_home):
+    sid = _unique_sid()
+    today = datetime.date.today().isoformat()
+
+    result = obsidian_utils._first_seen_date(sid)
+
+    assert result == today
+    marker = isolated_home / ".claude" / "obsidian-brain" / "sessions" / f"{sid}.json"
+    assert marker.exists()
+    assert oct(marker.stat().st_mode)[-3:] == "600"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["first_seen_date"] == today
+    assert "first_seen_iso" in payload
+
+
+def test_first_seen_date_idempotent_across_calls(isolated_home):
+    sid = _unique_sid()
+    first = obsidian_utils._first_seen_date(sid)
+    second = obsidian_utils._first_seen_date(sid)
+    third = obsidian_utils._first_seen_date(sid)
+    assert first == second == third
+
+
+def test_first_seen_date_survives_today_advance(isolated_home):
+    """Cross-midnight invariant: once the marker exists, advancing
+    date.today() must not change the returned value."""
+    sid = _unique_sid()
+    day_n = datetime.date(2026, 4, 25)
+    day_n_plus_1 = datetime.date(2026, 4, 26)
+
+    class _FrozenDate:
+        @staticmethod
+        def today():
+            return _FrozenDate._now
+
+    _FrozenDate._now = day_n
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        first = obsidian_utils._first_seen_date(sid)
+        assert first == day_n.isoformat()
+
+    _FrozenDate._now = day_n_plus_1
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        second = obsidian_utils._first_seen_date(sid)
+        assert second == day_n.isoformat()  # still day-N, not day-N+1
+
+
+def test_first_seen_date_corruption_self_heals(isolated_home):
+    sid = _unique_sid()
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    marker = marker_dir / f"{sid}.json"
+    marker.write_text("not valid json {", encoding="utf-8")
+
+    today = datetime.date.today().isoformat()
+    result = obsidian_utils._first_seen_date(sid)
+    assert result == today
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["first_seen_date"] == today
+
+    # Subsequent call returns the rewritten value, no further mutation
+    result2 = obsidian_utils._first_seen_date(sid)
+    assert result2 == today
+
+
+def test_first_seen_date_rejects_path_traversal_sid(isolated_home, capsys):
+    """A sid shaped like a path-traversal attempt must NOT escape the
+    marker directory; helper falls back to today's date and warns."""
+    today = datetime.date.today().isoformat()
+    result = obsidian_utils._first_seen_date("../../../etc/passwd")
+    assert result == today
+    # No marker file should have been created anywhere outside sessions/
+    sessions_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    if sessions_dir.exists():
+        assert list(sessions_dir.glob("*passwd*")) == []
+    captured = capsys.readouterr()
+    assert "unsafe sid" in captured.err.lower() or "refusing" in captured.err.lower()
+
+
+def test_first_seen_date_chmods_existing_loose_mode_dir(isolated_home):
+    """mkdir(mode=0o700, exist_ok=True) is a no-op on a pre-existing dir;
+    helper must explicitly chmod 0o700 if mode is too permissive."""
+    sessions = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    os.chmod(sessions, 0o755)  # simulate a previously-buggy permission
+    sid = _unique_sid()
+    obsidian_utils._first_seen_date(sid)
+    assert oct(sessions.stat().st_mode)[-3:] == "700"
+
+
+def test_first_seen_date_chmods_existing_loose_mode_marker(isolated_home):
+    """If a marker file exists with overly-permissive mode (e.g., from a
+    previous bug or manual edit), the helper must self-heal it to 0o600."""
+    sessions = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True, mode=0o700)
+    sid = _unique_sid()
+    marker = sessions / f"{sid}.json"
+    marker.write_text(
+        json.dumps({"first_seen_date": "2026-04-20", "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+    os.chmod(marker, 0o644)  # simulate a previously-buggy permission
+
+    obsidian_utils._first_seen_date(sid)
+    assert oct(marker.stat().st_mode)[-3:] == "600"
+
+
+def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, monkeypatch):
+    """get_session_context() fallback must compose its basename from
+    _first_seen_date(sid), not date.today() — so cross-midnight insights
+    and SessionEnd writes agree on the filename. Mock date.today() to a
+    different day than the marker so the test actually exercises the
+    divergence the helper prevents."""
+    sid = _unique_sid()
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name", lambda *a, **kw: "obsidian-brain")
+
+    marker_date = "2026-04-20"  # day-N
+    other_day = datetime.date(2026, 4, 22)  # day-N+2 — different from marker
+
+    # Pre-write a marker pointing at day-N
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    (marker_dir / f"{sid}.json").write_text(
+        json.dumps({"first_seen_date": marker_date, "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    class _FrozenDate:
+        @staticmethod
+        def today():
+            return other_day
+
+    # With date.today() mocked to day-N+2, the fallback must STILL produce
+    # the day-N basename via the marker. If the fallback ignored the marker
+    # and used date.today(), the basename would start with 2026-04-22.
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+
+    assert ctx["session_note_name"].startswith(f"{marker_date}-obsidian-brain-"), (
+        f"expected basename pinned to marker date {marker_date}, got {ctx['session_note_name']}"
+    )
+    # Must be byte-equal to make_filename(marker_date, ...)
+    expected = obsidian_utils.make_filename(marker_date, "obsidian-brain", sid)[:-3]
+    assert ctx["session_note_name"] == expected
+
+
+def test_helper_and_session_end_produce_byte_identical_basename(isolated_home, monkeypatch):
+    """Project-slug invariant: across many (project, sid) combinations,
+    get_session_context()'s fallback basename and the basename SessionEnd
+    would build via make_filename(_first_seen_date(sid), slugify(project), sid)
+    are byte-for-byte identical. Catches any future regression that
+    reintroduces a hand-composed slug or a different date source."""
+    projects = [
+        "obsidian-brain",
+        "tiny-vacation-agent",
+        "personal-ws",
+        "claude-code-skills",
+        "very-long-project-name-that-might-trip-truncation-logic",
+        "abc",
+        "name with spaces",
+        "name_with_underscores",
+        "obsidian-brain--issue-101-source-session-basename-stability",
+        "Mixed-Case-Project",
+    ]
+    for project in projects:
+        for _ in range(3):
+            sid = _unique_sid()
+            monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda s=sid: s)
+            monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                                lambda *a, project=project, **kw: project)
+
+            # Helper side
+            ctx = obsidian_utils.get_session_context()
+            helper_basename = ctx["session_note_name"]
+
+            # SessionEnd side — replicate the exact call shape
+            date_str = obsidian_utils._first_seen_date(sid)
+            session_end_filename = obsidian_utils.make_filename(
+                date_str,
+                obsidian_utils.slugify(project),
+                sid,
+            )
+            session_end_basename = session_end_filename[:-3]  # strip .md
+
+            assert helper_basename == session_end_basename, (
+                f"divergence for project={project!r}, sid={sid}:\n"
+                f"  helper:      {helper_basename}\n"
+                f"  session_end: {session_end_basename}"
+            )
+
+
+def test_session_end_filename_uses_marker_date(isolated_home, monkeypatch):
+    """SessionEnd reads _first_seen_date(sid), not date.today()."""
+    sid = _unique_sid()
+    # Pre-write a marker pointing at day-N (yesterday relative to "today")
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    (marker_dir / f"{sid}.json").write_text(
+        json.dumps({"first_seen_date": "2026-04-25", "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+
+    # Direct exercise of the helper SessionEnd uses
+    date_str = obsidian_utils._first_seen_date(sid)
+    assert date_str == "2026-04-25"
+
+    project_slug = obsidian_utils.slugify("obsidian-brain")
+    filename = obsidian_utils.make_filename(date_str, project_slug, sid)
+    assert filename.startswith("2026-04-25-obsidian-brain-")
+    assert filename.endswith(".md")
+
+
+def _write_note(path: Path, frontmatter: dict, body: str = "body\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append(body)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_peek_frontmatter_type_reads_session(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "claude-session", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) == "claude-session"
+
+
+def test_peek_frontmatter_type_reads_snapshot(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "claude-snapshot", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) == "claude-snapshot"
+
+
+def test_peek_frontmatter_type_returns_none_when_missing(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) is None
+
+
+def test_peek_frontmatter_project_path_strips_quotes(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {
+        "type": "claude-session",
+        "project_path": '"/Users/a/dev/obsidian-brain"',
+    })
+    assert obsidian_utils._peek_frontmatter_project_path(note) == "/Users/a/dev/obsidian-brain"
+
+
+def test_peek_frontmatter_field_empty_value_returns_none(tmp_path):
+    """An empty scalar (`field:` with no value) returns None, not ''.
+    Lets resolver call sites use truthy checks safely."""
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) is None
+
+
+def test_resolve_filters_snapshot_type(tmp_path):
+    """Defense-in-depth: even if a snapshot ever ends up with a session-shaped
+    filename (matching the resolver glob ``*-{h}.md``), the type filter must
+    exclude it. We deliberately give the snapshot a session-shaped name here
+    so the glob matches and the type filter is the only thing keeping it out."""
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "real",
+                 "project_path": '"/cwd/foo"'})
+    _write_note(sessions_dir / f"2026-04-20-snap-{h}.md",
+                {"type": "claude-snapshot", "session_id": "real"})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/foo"
+    )
+    assert basename == f"2026-04-20-foo-{h}"
+    assert collisions == []
+
+
+def test_resolve_disambiguates_by_project_path(tmp_path):
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a",
+                 "project_path": '"/cwd/a"'})
+    _write_note(sessions_dir / f"2026-04-20-proj-b-{h}.md",
+                {"type": "claude-session", "session_id": "b",
+                 "project_path": '"/cwd/b"'})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/a"
+    )
+    assert basename == f"2026-04-20-proj-a-{h}"
+    assert collisions == [f"2026-04-20-proj-b-{h}.md"]
+
+
+def test_resolve_double_collision_returns_none(tmp_path):
+    """Two session-type notes with same hash AND same project_path → ambiguous,
+    caller falls back to composed name."""
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a1",
+                 "project_path": '"/cwd/a"'})
+    _write_note(sessions_dir / f"2026-04-21-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a2",
+                 "project_path": '"/cwd/a"'})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/a"
+    )
+    assert basename is None
+    assert sorted(collisions) == sorted([
+        f"2026-04-20-proj-a-{h}.md",
+        f"2026-04-21-proj-a-{h}.md",
+    ])
+
+
+def test_resolve_no_match_returns_empty(tmp_path):
+    """Sanity: empty directory → (None, [])."""
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        tmp_path, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []
+
+
+def test_get_session_context_uses_type_aware_resolver(isolated_home, tmp_path, monkeypatch, capsys):
+    """get_session_context with a snapshot+session sharing the hash returns
+    the session, not the snapshot (#101 Fix C)."""
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                        lambda *a, **kw: "obsidian-brain")
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path / "obsidian-brain")
+    (tmp_path / "obsidian-brain").mkdir()
+    monkeypatch.chdir(tmp_path / "obsidian-brain")
+
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd}"'})
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}-snapshot-101010.md",
+                {"type": "claude-snapshot", "session_id": sid})
+
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx["session_note_name"] == f"2026-04-20-obsidian-brain-{h}"
+    # Should NOT be the snapshot
+    assert "snapshot" not in ctx["session_note_name"]
+
+
+def test_get_session_context_disambiguates_cross_project_hash_collision(
+    isolated_home, tmp_path, monkeypatch, capsys
+):
+    """When two session-type notes share the 4-char hash across projects,
+    get_session_context returns the cwd-matching one and emits a WARN
+    listing the other (#101 Fix C)."""
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                        lambda *a, **kw: "obsidian-brain")
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    cwd_a = str(tmp_path / "obsidian-brain")
+    (tmp_path / "obsidian-brain").mkdir()
+    monkeypatch.chdir(tmp_path / "obsidian-brain")
+
+    # Two session-type notes with the SAME hash but DIFFERENT project_path —
+    # this is the cross-project hash collision the resolver disambiguates.
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}.md",
+                {"type": "claude-session", "session_id": "sid-a",
+                 "project_path": f'"{cwd_a}"'})
+    _write_note(sessions / f"2026-04-21-other-project-{h}.md",
+                {"type": "claude-session", "session_id": "sid-b",
+                 "project_path": '"/some/other/project"'})
+
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx["session_note_name"] == f"2026-04-20-obsidian-brain-{h}", (
+        f"expected cwd-matching basename, got {ctx['session_note_name']}"
+    )
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert f"hash {h}" in captured.err
+    assert "other-project" in captured.err  # the OTHER session is named in the warning
+
+
+def test_is_resumed_session_filters_snapshot_type(tmp_path, monkeypatch):
+    """is_resumed_session must NOT return True when only a snapshot
+    exists with this hash (subsumes #86). Snapshot is given a session-shaped
+    filename so the resolver glob matches and the type filter is exercised."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    # Snapshot with a session-shaped filename — only the type filter excludes it
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-snapshot", "session_id": "different"})
+
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is False
+
+
+def test_is_resumed_session_returns_true_for_real_session(tmp_path, monkeypatch):
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd}"'})
+
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is True
+
+
+def test_is_resumed_session_handles_collision_pair(tmp_path, monkeypatch, capsys):
+    """Same-project two-session ambiguity (the original #86 scope):
+    is_resumed_session returns False (no unambiguous prior session for
+    THIS sid in THIS project), warns, and does not crash. Operator should
+    investigate the duplicates manually."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "old",
+                 "project_path": f'"{cwd}"'})
+    _write_note(sessions / f"2026-04-21-foo-{h}.md",
+                {"type": "claude-session", "session_id": "newer",
+                 "project_path": f'"{cwd}"'})
+
+    result = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid)
+    assert result is False  # ← changed from True
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err or "collide" in captured.err.lower()  # 'collide' (singular)
+
+
+def test_peek_frontmatter_field_handles_invalid_utf8(tmp_path, capsys):
+    """A file with invalid UTF-8 bytes returns None and logs to stderr,
+    rather than raising and breaking the resolver chain."""
+    note = tmp_path / "n.md"
+    note.write_bytes(b"---\ntype: claude-session\nbad: \xff\xfe\n---\n")
+    result = obsidian_utils._peek_frontmatter_type(note)
+    assert result is None
+    captured = capsys.readouterr()
+    assert "cannot read" in captured.err.lower() or "decode" in captured.err.lower()
+
+
+def test_peek_frontmatter_field_logs_empty_value(tmp_path, capsys):
+    """Empty-but-present field is logged as a possible corruption signal."""
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "", "session_id": "abc"})
+    result = obsidian_utils._peek_frontmatter_type(note)
+    assert result is None
+    captured = capsys.readouterr()
+    assert "empty" in captured.err.lower()
+
+
+def test_resolve_logs_when_sessions_dir_missing(tmp_path, capsys):
+    """When sessions_dir doesn't exist, resolver logs to stderr (so a
+    misconfigured vault path is observable), then returns no-match."""
+    missing = tmp_path / "nonexistent"
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        missing, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err.lower() or "no-match" in captured.err.lower()
+
+
+def test_is_resumed_session_returns_false_on_cross_project_collision(tmp_path, monkeypatch, capsys):
+    """Cross-project hash collision: a session-type note exists with the
+    matching hash but project_path != cwd. Function returns False (this
+    is NOT our resumed session) and warns."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    # Single session-type note belonging to a DIFFERENT project
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "other-project-sid",
+                 "project_path": '"/some/other/project"'})
+
+    result = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid)
+    assert result is False, (
+        "Cross-project hash collision should NOT mark this session as resumed; "
+        "the colliding note belongs to a different project."
+    )
+
+
+def test_safe_getcwd_returns_empty_on_cwd_gone(monkeypatch):
+    """When os.getcwd() raises (cwd deleted/unmounted — issue #105 territory),
+    _safe_getcwd returns empty string so callers fall back gracefully instead
+    of crashing SessionEnd."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    assert obsidian_utils._safe_getcwd() == ""
+
+
+def test_safe_getcwd_returns_empty_on_oserror(monkeypatch):
+    """OSError (permission, EIO) on os.getcwd() must also degrade gracefully."""
+    def _raise(*a, **kw):
+        raise OSError("EIO on cwd")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    assert obsidian_utils._safe_getcwd() == ""
+
+
+def test_resolver_glob_oserror_returns_none(tmp_path, monkeypatch, capsys):
+    """If glob raises OSError (transient I/O, permission), resolver returns
+    (None, []) and logs to stderr — does not propagate.
+
+    Patches Path.glob globally because the resolver does ``Path(sessions_dir)``
+    internally, which produces a fresh Path object whose `glob` method is
+    bound at call time.
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+
+    def _raising_glob(self, pattern):
+        raise OSError("simulated I/O error")
+    monkeypatch.setattr(Path, "glob", _raising_glob)
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []
+    captured = capsys.readouterr()
+    assert "glob failed" in captured.err.lower()
+
+
+def test_resolve_treats_type_missing_as_session(tmp_path):
+    """Legacy notes without an explicit `type:` frontmatter field still count
+    as session notes so resumed-session detection doesn't regress on
+    pre-existing vaults — matches the convention used by collect_open_items()
+    in hooks/open_item_dedup.py.
+    """
+    sessions = tmp_path
+    h = "abcd"
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"session_id": "abc", "project_path": '"/cwd/foo"'})  # NO type
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions, h, cwd="/cwd/foo"
+    )
+    assert basename == f"2026-04-20-foo-{h}"
+    assert collisions == []
+
+
+def test_is_resumed_session_uses_provided_cwd_over_getcwd(tmp_path, monkeypatch):
+    """When ``cwd`` is passed explicitly, is_resumed_session uses it instead
+    of os.getcwd(). SessionEnd passes hook_input["cwd"] (Claude Code's
+    authoritative project path) so a hook process that chdir'd elsewhere
+    still classifies the session against the right project.
+    """
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    project_a = tmp_path / "real-project"
+    project_a.mkdir()
+    cwd_a = str(project_a)
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd_a}"'})
+
+    # Force os.getcwd() into a DIFFERENT directory; the provided cwd must win.
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    # Without cwd param: returns False (os.getcwd() doesn't match note).
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is False
+
+    # With cwd param: returns True (provided cwd matches note).
+    assert obsidian_utils.is_resumed_session(
+        str(vault), "claude-sessions", sid, cwd=cwd_a
+    ) is True
+
+
+# ─── Issue #105: _resolve_project_basename ───────────────────────────
+
+def test_resolve_project_basename_happy_path(monkeypatch, tmp_path):
+    """Happy path: os.getcwd works → returns its basename."""
+    target = tmp_path / "some-project"
+    target.mkdir()
+    monkeypatch.chdir(target)
+    assert obsidian_utils._resolve_project_basename() == "some-project"
+
+
+def test_resolve_project_basename_falls_back_to_env(monkeypatch):
+    """When os.getcwd raises, returns basename of CLAUDE_PROJECT_DIR."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/tmp/fake-project-dir/my-proj")
+    assert obsidian_utils._resolve_project_basename() == "my-proj"
+
+
+def test_resolve_project_basename_returns_none_when_both_unavailable(monkeypatch):
+    """When both cwd and CLAUDE_PROJECT_DIR fail, returns None for caller
+    to treat as 'cannot determine project'."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    assert obsidian_utils._resolve_project_basename() is None
+
+
+def test_resolve_project_basename_normalizes_root_cwd_to_none(monkeypatch):
+    """cwd='/' has basename '' which would unsafely become a cross-project
+    glob ('~/.claude/projects/*/*.jsonl') downstream. Normalize to None per
+    Copilot R2 PR #113 so caller falls through to the strict layer-4 scan."""
+    monkeypatch.setattr(os, "getcwd", lambda: "/")
+    assert obsidian_utils._resolve_project_basename() is None
+
+
+def test_resolve_project_basename_normalizes_env_trailing_slash(monkeypatch):
+    """CLAUDE_PROJECT_DIR ending with '/' has basename '' which would unsafely
+    become a cross-project glob downstream. Strip trailing slash before
+    basename, then normalize empty to None per Copilot R2 PR #113."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/path/to/myproj/")
+    assert obsidian_utils._resolve_project_basename() == "myproj"
+
+
+def test_resolve_project_basename_env_root_normalizes_to_none(monkeypatch):
+    """CLAUDE_PROJECT_DIR='/' normalizes to None (root path is not a project)."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/")
+    assert obsidian_utils._resolve_project_basename() is None
+
+
+# ─── Issue #105: _recent_bootstrap_sid ────────────────────────────────
+
+def _seed_bootstrap(home: Path, project: str, sid: str, mtime_offset: float = 0.0) -> Path:
+    """Helper: create a sid-<project> bootstrap file under home with given content
+    and set mtime to (now + offset). Returns the file path."""
+    import time
+    bdir = home / ".claude" / "obsidian-brain"
+    bdir.mkdir(parents=True, exist_ok=True)
+    bdir.chmod(0o700)
+    path = bdir / f"sid-{project}"
+    path.write_text(sid)
+    if mtime_offset != 0.0:
+        ts = time.time() + mtime_offset
+        os.utime(path, (ts, ts))
+    return path
+
+
+def test_recent_bootstrap_sid_zero_recent_returns_none(isolated_home):
+    """Empty bootstrap dir → None."""
+    assert obsidian_utils._recent_bootstrap_sid() is None
+
+
+def test_recent_bootstrap_sid_exactly_one_recent_returns_sid(isolated_home):
+    """Single recent bootstrap → returns its content."""
+    sid = _unique_sid()
+    _seed_bootstrap(isolated_home, "myproj", sid)
+    assert obsidian_utils._recent_bootstrap_sid() == sid
+
+
+def test_recent_bootstrap_sid_two_recent_returns_none(isolated_home):
+    """Two recent bootstraps → None (strict; never silently mis-attributes)."""
+    _seed_bootstrap(isolated_home, "proj-a", _unique_sid())
+    _seed_bootstrap(isolated_home, "proj-b", _unique_sid())
+    assert obsidian_utils._recent_bootstrap_sid() is None
+
+
+def test_recent_bootstrap_sid_skips_tmp_partials(isolated_home):
+    """sid-*.tmp atomic-write residue is not counted as a bootstrap."""
+    sid = _unique_sid()
+    # One real recent bootstrap + one .tmp partial → still exactly-one
+    _seed_bootstrap(isolated_home, "myproj", sid)
+    tmp = isolated_home / ".claude" / "obsidian-brain" / ".ob-sid-abc.tmp"
+    tmp.write_text("garbage")
+    assert obsidian_utils._recent_bootstrap_sid() == sid
+
+
+def test_recent_bootstrap_sid_skips_stale(isolated_home):
+    """Bootstrap file outside recency window → None."""
+    # Set mtime 700s in the past (window default is 600s)
+    _seed_bootstrap(isolated_home, "myproj", _unique_sid(), mtime_offset=-700.0)
+    assert obsidian_utils._recent_bootstrap_sid() is None
+
+
+def test_recent_bootstrap_sid_skips_empty_content(isolated_home):
+    """Recent bootstrap with empty/whitespace content → None (corrupted write)."""
+    bdir = isolated_home / ".claude" / "obsidian-brain"
+    bdir.mkdir(parents=True, exist_ok=True)
+    bdir.chmod(0o700)
+    (bdir / "sid-myproj").write_text("   \n  ")
+    assert obsidian_utils._recent_bootstrap_sid() is None
+
+
+def test_recent_bootstrap_sid_rejects_unsafe_sid_format(isolated_home):
+    """Bootstrap content failing _SID_FILENAME_SAFE regex → None.
+
+    Without this validation, a corrupted or attacker-controlled bootstrap file
+    with content like '../../../tmp/foo' could propagate path-traversal strings
+    into cache_get/cache_set composition. Per Copilot R1 PR #113.
+    """
+    bdir = isolated_home / ".claude" / "obsidian-brain"
+    bdir.mkdir(parents=True, exist_ok=True)
+    bdir.chmod(0o700)
+    # Attacker-controlled / corrupted SIDs that should all be rejected
+    for unsafe in [
+        "../../../tmp/escape",        # path traversal
+        "/absolute/path",             # absolute path
+        "sid with spaces",            # whitespace
+        "sid\nwith-newline",          # newline
+        "sid\twith-tab",              # tab
+        "sid*glob",                   # glob char
+        "sid/with-slash",             # path separator
+        "sid\\with-backslash",        # backslash
+        "x" * 200,                    # exceeds 128-char limit
+    ]:
+        # Reset dir for each iteration so this is exactly-one
+        for f in bdir.glob("sid-*"):
+            f.unlink()
+        (bdir / "sid-myproj").write_text(unsafe)
+        assert obsidian_utils._recent_bootstrap_sid() is None, \
+            f"Unsafe SID format should be rejected: {unsafe!r}"
+
+
+# ─── Issue #105: _resolve_session_id integration ──────────────────────
+
+def test_resolve_session_id_cwd_gone_uses_recent_bootstrap(isolated_home, monkeypatch):
+    """Headline regression: cwd-gone + valid recent bootstrap → returns the SID
+    via layer 4. This is the scenario from 2026-04-24 retros that motivated #105."""
+    sid = _unique_sid()
+    _seed_bootstrap(isolated_home, "myworktree", sid)
+
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+    assert obsidian_utils._resolve_session_id() == sid
+
+
+def test_resolve_session_id_cwd_gone_no_bootstrap_returns_unknown(isolated_home, monkeypatch):
+    """Cwd-gone + no recent bootstrap → 'unknown' sentinel (graceful, never raises)."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+    assert obsidian_utils._resolve_session_id() == "unknown"
+
+
+def test_resolve_session_id_happy_path_uses_existing_layers(isolated_home, monkeypatch, tmp_path):
+    """Cwd valid + bootstrap valid → resolves via layer 2 (no behavior change)."""
+    sid = _unique_sid()
+    project = "happypath-proj"
+
+    # Seed the existing bootstrap fast path machinery: write sid-<project> AND
+    # a JSONL the fast path can stat.
+    _seed_bootstrap(isolated_home, project, sid)
+    cc_dir = isolated_home / ".claude" / "projects" / f"-Users-test-{project}"
+    cc_dir.mkdir(parents=True, exist_ok=True)
+    (cc_dir / f"{sid}.jsonl").write_text("{}\n")
+
+    target = tmp_path / project
+    target.mkdir()
+    monkeypatch.chdir(target)
+
+    # _bootstrap_prefix() reads the module-level _BOOTSTRAP_PREFIX which is
+    # frozen at import time to the real $HOME. Redirect it for this test so
+    # the fast path actually finds the seeded bootstrap.
+    bdir = isolated_home / ".claude" / "obsidian-brain"
+    monkeypatch.setattr(
+        obsidian_utils, "_BOOTSTRAP_PREFIX", str(bdir) + "/sid-"
+    )
+
+    assert obsidian_utils._resolve_session_id(allow_bootstrap=True) == sid
+
+
+def test_resolve_session_id_slow_path_skips_layer_2(isolated_home, monkeypatch, tmp_path):
+    """allow_bootstrap=False (used by _slow_path_newest_sid) skips layer 2
+    even when bootstrap exists. Preserves the existing 'health-check is
+    bootstrap-blind' contract."""
+    project = "slowpath-proj"
+    bootstrap_sid = _unique_sid()
+    jsonl_sid = _unique_sid()
+
+    # Seed bootstrap with one SID, JSONL with a different one — slow path must
+    # return the JSONL's SID, ignoring the bootstrap file entirely.
+    _seed_bootstrap(isolated_home, project, bootstrap_sid)
+    cc_dir = isolated_home / ".claude" / "projects" / f"-Users-test-{project}"
+    cc_dir.mkdir(parents=True, exist_ok=True)
+    (cc_dir / f"{jsonl_sid}.jsonl").write_text("{}\n")
+
+    target = tmp_path / project
+    target.mkdir()
+    monkeypatch.chdir(target)
+
+    # Layer 2 is skipped here, so _BOOTSTRAP_PREFIX redirect is unnecessary;
+    # but the slow-path uses _glob_project_jsonls which uses expanduser at
+    # call time → HOME monkeypatch (already done by isolated_home) is enough.
+    assert obsidian_utils._resolve_session_id(allow_bootstrap=False) == jsonl_sid
+
+
+def test_try_bootstrap_fast_path_rejects_unsafe_cached_sid(isolated_home, monkeypatch):
+    """_try_bootstrap_fast_path validates cached_sid against _SID_FILENAME_SAFE
+    before trusting it. Symmetric to the validation in _recent_bootstrap_sid.
+    Without this, a corrupted sid-<project> file with content like '../foo'
+    could propagate path-traversal strings into cache_get/cache_set composition.
+    Per Copilot R2 PR #113."""
+    project = "fastpath-proj"
+    bdir = isolated_home / ".claude" / "obsidian-brain"
+    bdir.mkdir(parents=True, exist_ok=True)
+    bdir.chmod(0o700)
+    # Write an unsafe (path-traversal) value into the bootstrap.
+    (bdir / f"sid-{project}").write_text("../../../tmp/escape")
+    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(bdir) + "/sid-")
+
+    # No JSONL setup is needed here: this test asserts that the fast path
+    # rejects unsafe bootstrap content before trusting or composing with it.
+    assert obsidian_utils._try_bootstrap_fast_path(project) is None
+
+
+def test_resolve_session_id_slow_path_skips_layer_4_recent_bootstrap(isolated_home, monkeypatch):
+    """allow_bootstrap=False (used by _slow_path_newest_sid) skips BOTH layer 2
+    AND layer 4 — does not trust the cross-project recent-bootstrap scan either.
+    Preserves the bootstrap-blind health-check contract that check_hook_status
+    relies on at obsidian_utils.py:827."""
+    project = "healthcheck-proj"
+    bootstrap_sid = _unique_sid()
+
+    # Seed a recent bootstrap (would normally be picked up by layer 4)
+    _seed_bootstrap(isolated_home, project, bootstrap_sid)
+
+    # cwd valid, but NO matching JSONL exists for this project — slow path
+    # returns "unknown" → without the fix, layer 4 would find bootstrap_sid
+    # and return it. With the fix, layer 4 is gated off → returns "unknown".
+    target = isolated_home / project
+    target.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(target)
+
+    assert obsidian_utils._resolve_session_id(allow_bootstrap=False) == "unknown"

--- a/plugins/obsidian-brain/tests/test_obsidian_utils.py
+++ b/plugins/obsidian-brain/tests/test_obsidian_utils.py
@@ -4,9 +4,19 @@
 import hashlib
 import json
 import os
+import shutil
+import subprocess
 import uuid
+from pathlib import Path
 
 import pytest
+
+# Tests that shell out to `git` need it on PATH; skip cleanly otherwise so
+# CI/dev environments without git don't hard-fail (Copilot R5).
+_GIT_AVAILABLE = shutil.which("git") is not None
+_REQUIRES_GIT = pytest.mark.skipif(
+    not _GIT_AVAILABLE, reason="git binary not available on PATH"
+)
 
 import obsidian_utils
 
@@ -2036,3 +2046,281 @@ class TestUpgradeBatch:
         assert "status: summarized" in updated
         assert "## Summary" in updated
         assert "Did a thing." in updated
+
+
+# ===========================================================================
+# Section N: canonical_project_name — worktree-aware project name derivation
+# ===========================================================================
+
+
+def _init_git_repo(path: Path) -> None:
+    """Create a minimal git repo at `path` for testing.
+
+    Uses `git init` without `-b <branch>` so the helper works on older git
+    versions that predate that flag (Copilot R5). The default branch name
+    isn't asserted on by any caller — only the repo basename matters.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
+    (path / "README.md").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_main_repo(tmp_path, monkeypatch):
+    """In the main repo, canonical name = repo basename."""
+    repo = tmp_path / "my-project"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    assert obsidian_utils.canonical_project_name() == "my-project"
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_in_worktree(tmp_path, monkeypatch):
+    """In a worktree, canonical name = main repo basename, not worktree basename."""
+    repo = tmp_path / "my-project"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "my-project--feature-branch"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/x", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(worktree)
+    # Despite the worktree's directory basename being "my-project--feature-branch",
+    # canonical_project_name returns the main-repo's basename.
+    assert obsidian_utils.canonical_project_name() == "my-project"
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_falls_back_outside_git(tmp_path, monkeypatch):
+    """Outside a git repo, fall back to cwd basename."""
+    nongit = tmp_path / "Plain Folder"
+    nongit.mkdir()
+    monkeypatch.chdir(nongit)
+    # The fallback applies normalization (spaces → hyphens, lowercase).
+    assert obsidian_utils.canonical_project_name() == "plain-folder"
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_explicit_cwd_arg(tmp_path):
+    """Explicit cwd= arg used instead of process cwd."""
+    repo = tmp_path / "sample-repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    # Note: NOT chdir-ing — using cwd= arg explicitly.
+    assert obsidian_utils.canonical_project_name(cwd=str(repo)) == "sample-repo"
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_normalizes_underscores(tmp_path, monkeypatch):
+    """Underscores and spaces normalize to hyphens, lowercase."""
+    repo = tmp_path / "Snake_Case_Repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    assert obsidian_utils.canonical_project_name() == "snake-case-repo"
+
+
+def test_canonical_project_name_handles_deleted_cwd(monkeypatch):
+    """When the current working directory has been deleted (e.g., a worktree
+    removed mid-session via `gh pr merge --delete-branch`), os.getcwd() raises
+    FileNotFoundError. Hooks must exit 0, so canonical_project_name returns
+    'unknown' rather than propagating the exception (review C4)."""
+    def _raise_fnf(*args, **kwargs):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(obsidian_utils.os, "getcwd", _raise_fnf)
+    monkeypatch.setattr(
+        obsidian_utils,
+        "_git_canonical_project_name_with_reason",
+        lambda cwd=None: (None, "not-a-repo"),
+    )
+    assert obsidian_utils.canonical_project_name(None) == "unknown"
+
+
+@_REQUIRES_GIT
+def test_canonical_project_name_no_warn_when_not_a_repo(tmp_path, monkeypatch, capsys):
+    """Copilot R2: the SF7 warning must NOT fire for the normal 'cwd is not
+    inside a git repo' case (returncode != 0). That's an expected operating
+    condition; warning would be noise.
+    """
+    monkeypatch.setattr(obsidian_utils, "_git_fallback_warned", False)
+    nongit = tmp_path / "Plain Folder"
+    nongit.mkdir()
+    monkeypatch.chdir(nongit)
+    capsys.readouterr()  # drain
+    assert obsidian_utils.canonical_project_name() == "plain-folder"
+    captured = capsys.readouterr()
+    assert "[obsidian_utils]" not in captured.err, (
+        f"warning should not fire for not-a-repo case, got stderr: {captured.err!r}"
+    )
+
+
+def test_canonical_project_name_warns_once_when_git_unavailable(monkeypatch, capsys):
+    """Copilot R2: the SF7 warning fires for genuine git errors
+    (git-unavailable / empty-output / resolve-failed) and is one-shot per
+    process. Multiple calls produce exactly one stderr line.
+    """
+    monkeypatch.setattr(obsidian_utils, "_git_fallback_warned", False)
+    monkeypatch.setattr(
+        obsidian_utils,
+        "_git_canonical_project_name_with_reason",
+        lambda cwd=None: (None, "git-unavailable"),
+    )
+    monkeypatch.setattr(obsidian_utils.os, "getcwd", lambda: "/tmp/some-dir")
+    capsys.readouterr()  # drain
+
+    obsidian_utils.canonical_project_name()
+    obsidian_utils.canonical_project_name()
+    obsidian_utils.canonical_project_name()
+
+    captured = capsys.readouterr()
+    occurrences = captured.err.count(
+        "[obsidian_utils] canonical_project_name: git error"
+    )
+    assert occurrences == 1, (
+        f"warning should fire exactly once across 3 calls, got {occurrences} "
+        f"in stderr: {captured.err!r}"
+    )
+    assert "git-unavailable" in captured.err
+
+
+@_REQUIRES_GIT
+def test_git_canonical_project_name_with_reason_distinguishes_failure_modes(
+    tmp_path, monkeypatch
+):
+    """The new (name, reason) helper distinguishes: ok / not-a-repo /
+    git-unavailable / empty-output / resolve-failed. Used by canonical_project_name
+    to suppress noise for the common 'not-a-repo' case (Copilot R2).
+    """
+    # not-a-repo: real fs, no .git
+    nongit = tmp_path / "no-repo"
+    nongit.mkdir()
+    name, reason = obsidian_utils._git_canonical_project_name_with_reason(str(nongit))
+    assert name is None
+    assert reason == "not-a-repo"
+
+    # git-unavailable: subprocess.run raises OSError
+    def _raise(*args, **kwargs):
+        raise OSError("git binary missing")
+    monkeypatch.setattr(obsidian_utils.subprocess, "run", _raise)
+    name, reason = obsidian_utils._git_canonical_project_name_with_reason(str(nongit))
+    assert name is None
+    assert reason == "git-unavailable"
+
+
+@_REQUIRES_GIT
+def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):
+    """get_session_context's `project` field uses canonical naming."""
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(worktree)
+    # session_id may be 'unknown' in test env — that's fine; we only check project.
+    ctx = obsidian_utils.get_session_context()
+    assert ctx["project"] == "obsidian-brain"
+
+
+@_REQUIRES_GIT
+def test_extract_session_metadata_returns_canonical_project(tmp_path):
+    """extract_session_metadata's `project` field uses canonical naming."""
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    meta = obsidian_utils.extract_session_metadata([], cwd=str(worktree))
+    assert meta["project"] == "obsidian-brain"
+    # project_path should still be the WORKTREE path, since that's where
+    # the session actually ran.
+    assert meta["project_path"] == str(worktree)
+
+
+@_REQUIRES_GIT
+def test_get_session_context_cache_key_isolates_distinct_worktrees(tmp_path, monkeypatch):
+    """T7: get_session_context's cache must isolate distinct worktrees of
+    the same repo so a call from one worktree doesn't return cached state
+    from a sibling worktree.
+
+    Distinct worktrees have distinct CC session_ids (each owns its own
+    JSONL), so the per-session cache file (~/.claude/obsidian-brain/cache-<sid>.json)
+    is naturally partitioned by session. The cache_key within that file
+    includes (vault_path, sessions_folder) — anything else that varies
+    across worktrees (e.g., note basenames in vault_path) would still
+    collide because vault_path is shared across worktrees.
+
+    This test verifies the realistic case: two sessions with different
+    SIDs from two worktrees produce different cache files, so call 2
+    cannot inherit call 1's value. If a future change moves the cache
+    file to be SID-independent without adding a worktree-discriminator
+    to cache_key, this test will fail.
+    """
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / "cache-"))
+
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    vault = tmp_path / "vault"
+    sessions_dir = vault / "claude-sessions"
+    sessions_dir.mkdir(parents=True)
+
+    # Simulate two distinct CC sessions: SID1 (from main repo) and SID2 (from worktree)
+    sid1 = "11111111-1111-1111-1111-111111111111"
+    sid2 = "22222222-2222-2222-2222-222222222222"
+
+    # Place a session note matching SID1's hash so the basename lookup
+    # produces a non-default value worth caching/comparing.
+    h1 = hashlib.sha256(sid1.encode()).hexdigest()[:4]
+    h2 = hashlib.sha256(sid2.encode()).hexdigest()[:4]
+    (sessions_dir / f"2026-04-25-obsidian-brain-{h1}.md").write_text(
+        "---\ntype: claude-session\nsession_id: " + sid1 + "\n---\n", encoding="utf-8"
+    )
+    (sessions_dir / f"2026-04-25-obsidian-brain-{h2}.md").write_text(
+        "---\ntype: claude-session\nsession_id: " + sid2 + "\n---\n", encoding="utf-8"
+    )
+
+    # Call 1: from main repo with SID1
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid1)
+    ctx1 = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx1["session_id"] == sid1
+    assert ctx1["hash"] == h1
+
+    # Call 2: from worktree with SID2 — must NOT return ctx1's hash
+    monkeypatch.chdir(worktree)
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid2)
+    ctx2 = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx2["session_id"] == sid2, (
+        f"cache leaked across worktrees: expected SID2 ({sid2}), got "
+        f"{ctx2['session_id']}"
+    )
+    assert ctx2["hash"] == h2, (
+        f"cache leaked across worktrees: expected hash {h2}, got {ctx2['hash']}"
+    )
+    # And canonical project naming must agree on both calls
+    assert ctx1["project"] == ctx2["project"] == "obsidian-brain"

--- a/plugins/obsidian-brain/tests/test_snapshot_e2e.py
+++ b/plugins/obsidian-brain/tests/test_snapshot_e2e.py
@@ -1,0 +1,408 @@
+"""End-to-end integration test for the snapshot → /recall pipeline (issue #50).
+
+Exercises the full 5-step cycle with real hook subprocess invocations and
+in-process obsidian_utils calls. CI-required.
+
+Pipeline:
+    1. obsidian_context_snapshot.py (subprocess) → snapshot note on disk
+    2. obsidian_session_log.py     (subprocess) → session note with `snapshots:` back-ref
+    3. find_unsummarized_notes()   (in-proc)   → [snapshot, session] in bias-sorted order
+    4. upgrade_unsummarized_note() (in-proc, Haiku monkeypatched) → status: summarized
+       (exercised for BOTH session and snapshot to cover the generate_summary
+       vs generate_snapshot_summary dispatch in upgrade_unsummarized_note)
+    5. build_context_brief()       (in-proc)   → nested `↳ HH:MM:SS` row + snapshot_count: 1
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import obsidian_utils  # conftest.py inserts hooks/ onto sys.path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SNAPSHOT = REPO_ROOT / "hooks" / "obsidian_context_snapshot.py"
+HOOK_SESSION_LOG = REPO_ROOT / "hooks" / "obsidian_session_log.py"
+
+SID = "e2e-test-session-12345"
+PROJECT = "fake-cwd"
+SLUG = "fake-cwd"
+
+
+def _write_config(home_dir: Path, vault_path: Path) -> Path:
+    """Write obsidian-brain-config.json pointing at the tmp vault."""
+    cfg_dir = home_dir / ".claude"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "vault_path": str(vault_path),
+        "sessions_folder": "claude-sessions",
+        "insights_folder": "claude-insights",
+        "auto_log_enabled": True,
+        "snapshot_on_compact": True,
+        "snapshot_on_clear": True,
+        "min_messages": 0,
+        "min_duration_minutes": 0,
+        "summary_model": "haiku",
+    }
+    cfg_path = cfg_dir / "obsidian-brain-config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    cfg_path.chmod(0o600)
+    return cfg_path
+
+
+def _write_transcript(home_dir: Path, slug: str, session_id: str) -> Path:
+    """Write a 3-line JSONL transcript fixture under ~/.claude/projects/<slug>/.
+
+    Filename is `{session_id}.jsonl` so that `find_transcript_jsonl()` (which
+    globs for `{session_id}.jsonl` under `~/.claude/projects/**/`) discovers
+    the fixture and `upgrade_unsummarized_note()` exercises the JSONL source
+    branch instead of falling through to the raw-note fallback.
+    """
+    proj_dir = home_dir / ".claude" / "projects" / slug
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    transcript = proj_dir / f"{session_id}.jsonl"
+    lines = [
+        {"type": "user", "message": {"content": "Fix the snapshot pipeline."}},
+        {"type": "assistant", "message": {"content": "Writing the test now."}},
+        {"type": "user", "message": {"content": "Looks good — ship it."}},
+    ]
+    transcript.write_text(
+        "\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8"
+    )
+    return transcript
+
+
+def _write_path_shim(bin_dir: Path) -> Path:
+    """Write a `claude` PATH shim emitting a canned summary on any call.
+
+    Defense-in-depth for **hook subprocesses**: neither production hook calls
+    `claude -p` (summarization is deferred to /recall), so this shim is never
+    hit in the hot path — but if a hook ever regresses to shelling out, this
+    keeps the subprocess leg hermetic. In-process `claude -p` calls made by
+    obsidian_utils (e.g. inside `upgrade_unsummarized_note`) are intercepted
+    separately by the monkeypatch on `obsidian_utils.subprocess.run` installed
+    in Stage 4 — not by this shim.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "claude"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "cat <<'EOF'\n"
+        "## Summary\n"
+        "Canned E2E summary from PATH shim.\n"
+        "\n"
+        "## Key Decisions\n"
+        "- None noted.\n"
+        "\n"
+        "## Changes Made\n"
+        "- None noted.\n"
+        "\n"
+        "## Errors Encountered\n"
+        "- None.\n"
+        "\n"
+        "## Open Questions / Next Steps\n"
+        "- None.\n"
+        "\n"
+        "IMPORTANCE: 5\n"
+        "EOF\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return shim
+
+
+def _hook_env(tmp_path: Path) -> dict:
+    """Env dict for subprocess hook invocations.
+
+    Sandboxes HOME (config lookups, `~/.claude/projects/` transcript search,
+    default vault DB path all route into `tmp_path/home`), prepends the
+    `tmp_path/bin` PATH shim, and sets PYTHONPATH so the hook can import the
+    in-tree `obsidian_utils`.
+    """
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{tmp_path / 'bin'}{os.pathsep}{env.get('PATH', '')}"
+    env["PYTHONPATH"] = f"{REPO_ROOT / 'hooks'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return env
+
+
+def test_snapshot_e2e_pipeline(tmp_path, monkeypatch):
+    """Fire both hooks, then walk the in-process pipeline, asserting at every boundary."""
+
+    # --- Stage 0: fixtures ---
+    vault = tmp_path / "vault"
+    sessions_dir = vault / "claude-sessions"
+    insights_dir = vault / "claude-insights"
+    sessions_dir.mkdir(parents=True)
+    insights_dir.mkdir(parents=True)
+
+    home = tmp_path / "home"
+    _write_config(home, vault)
+    transcript = _write_transcript(home, SLUG, SID)
+    _write_path_shim(tmp_path / "bin")
+
+    # Redirect HOME for in-process calls so any indirect Path.home() lookup
+    # (e.g. default ensure_index db path) resolves into the sandbox.
+    monkeypatch.setenv("HOME", str(home))
+
+    # --- Stage 1: fire the snapshot hook ---
+    snapshot_payload = {
+        "session_id": SID,
+        "cwd": str(tmp_path / "fake-cwd"),
+        "transcript_path": str(transcript),
+        "source": "compact",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SNAPSHOT)],
+        input=json.dumps(snapshot_payload),
+        env=_hook_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"snapshot hook exit={proc.returncode}\nstderr:\n{proc.stderr}")
+
+    snapshot_files = sorted(sessions_dir.glob("*-snapshot-*.md"))
+    assert len(snapshot_files) == 1, (
+        f"expected exactly 1 snapshot file, got {len(snapshot_files)}: "
+        f"{[f.name for f in snapshot_files]}\nhook stderr:\n{proc.stderr}"
+    )
+    snapshot_path = snapshot_files[0]
+
+    snapshot_text = snapshot_path.read_text(encoding="utf-8")
+    assert "type: claude-snapshot" in snapshot_text
+    assert f"session_id: {SID}" in snapshot_text
+    assert f"project: {PROJECT}" in snapshot_text
+    assert "status: auto-logged" in snapshot_text
+    assert "trigger: compact" in snapshot_text
+    assert "# Context Snapshot:" in snapshot_text
+
+    # --- Stage 2: fire the session-log hook ---
+    session_payload = {
+        "session_id": SID,
+        "cwd": str(tmp_path / "fake-cwd"),
+        "transcript_path": str(transcript),
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SESSION_LOG)],
+        input=json.dumps(session_payload),
+        env=_hook_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"session-log hook exit={proc.returncode}\nstderr:\n{proc.stderr}")
+
+    session_files = [
+        f for f in sessions_dir.glob("*.md")
+        if "-snapshot-" not in f.name
+    ]
+    assert len(session_files) == 1, (
+        f"expected exactly 1 session file, got {len(session_files)}: "
+        f"{[f.name for f in session_files]}\nhook stderr:\n{proc.stderr}"
+    )
+    session_path = session_files[0]
+
+    session_text = session_path.read_text(encoding="utf-8")
+    assert "type: claude-session" in session_text
+    assert f"session_id: {SID}" in session_text
+    assert "status: auto-logged" in session_text
+
+    # Back-reference check: the snapshot wikilink must live INSIDE the
+    # session note's frontmatter `snapshots:` YAML list — not merely somewhere
+    # in the body (which would slip past if, e.g., the wikilink leaked into a
+    # rendered summary while the YAML list was silently emptied).
+    fm_end = session_text.index("\n---", 3)
+    frontmatter = session_text[:fm_end]
+    snapshot_stem = snapshot_path.stem
+    assert re.search(r"^snapshots:", frontmatter, re.MULTILINE), (
+        "session note frontmatter missing `snapshots:` YAML key"
+    )
+    # Producer format at hooks/obsidian_session_log.py:97-98 is
+    # `  - "[[<stem>]]"` (two-space indent, hyphen, quoted wikilink).
+    assert f'  - "[[{snapshot_stem}]]"' in frontmatter, (
+        f'expected `  - "[[{snapshot_stem}]]"` under `snapshots:` in '
+        f"frontmatter:\n{frontmatter}"
+    )
+
+    # --- Stage 3: find_unsummarized_notes returns both session + snapshot ---
+    result = json.loads(
+        obsidian_utils.find_unsummarized_notes(
+            str(vault), "claude-sessions", PROJECT
+        )
+    )
+    assert result["auto_fixed"] == 0, (
+        f"unexpected auto-fix on fresh notes: {result}"
+    )
+    # Order is load-bearing for /recall cohesion: snapshots must sort before
+    # their parent session within the same session_id group so /recall
+    # presents chronologically correct context. find_unsummarized_notes
+    # enforces that via an explicit type-bias key (see obsidian_utils.py
+    # `_bias_key` at lines 1682-1699 — snapshots get rank 0, sessions rank 1
+    # within a session_id group), NOT via a reverse-lexicographic filename
+    # trick on the outer sort.
+    assert result["unsummarized"] == [str(snapshot_path), str(session_path)], (
+        f"expected [snapshot, session] order, got: {result['unsummarized']}"
+    )
+
+    # --- Stage 4: upgrade_unsummarized_note (Haiku monkeypatched) ---
+    CANNED_SUMMARY = (
+        "## Summary\n"
+        "E2E test session exercising the snapshot integration pipeline.\n"
+        "\n"
+        "## Key Decisions\n"
+        "- None noted.\n"
+        "\n"
+        "## Changes Made\n"
+        "- None noted.\n"
+        "\n"
+        "## Errors Encountered\n"
+        "- None.\n"
+        "\n"
+        "## Open Questions / Next Steps\n"
+        "- None.\n"
+        "\n"
+        "IMPORTANCE: 5\n"
+    )
+    _real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        # Intercept `claude -p ...`; delegate everything else.
+        if isinstance(cmd, (list, tuple)) and len(cmd) >= 2 \
+                and cmd[0] == "claude" and cmd[1] == "-p":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=CANNED_SUMMARY, stderr=""
+            )
+        return _real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr("obsidian_utils.subprocess.run", fake_run)
+
+    status = obsidian_utils.upgrade_unsummarized_note(
+        str(session_path), str(vault), "claude-sessions", PROJECT
+    )
+    assert status.startswith("Upgraded "), (
+        f"upgrade_unsummarized_note did not succeed: {status!r}"
+    )
+
+    session_text_after = session_path.read_text(encoding="utf-8")
+    assert "status: summarized" in session_text_after, (
+        f"expected status: summarized after upgrade, got:\n{session_text_after[:2000]}"
+    )
+    # Summary body present (find the section header and at least one char of content).
+    summary_match = re.search(
+        r"^## Summary\n(.+?)(?=\n^## |\Z)",
+        session_text_after,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert summary_match and summary_match.group(1).strip(), (
+        "expected non-empty `## Summary` section after upgrade"
+    )
+
+    # Also upgrade the SNAPSHOT note. upgrade_unsummarized_note dispatches
+    # snapshots through generate_snapshot_summary (a distinct code path from
+    # the generate_summary used for sessions above). Without this, the
+    # snapshot-type routing branch is never exercised by the E2E test.
+    snap_status = obsidian_utils.upgrade_unsummarized_note(
+        str(snapshot_path), str(vault), "claude-sessions", PROJECT
+    )
+    assert snap_status.startswith("Upgraded "), (
+        f"upgrade_unsummarized_note on snapshot did not succeed: {snap_status!r}"
+    )
+    snapshot_text_after = snapshot_path.read_text(encoding="utf-8")
+    assert "status: summarized" in snapshot_text_after, (
+        f"expected snapshot `status: summarized` after upgrade, got:\n"
+        f"{snapshot_text_after[:2000]}"
+    )
+
+    # --- Stage 5: build_context_brief nested row + snapshot_count ---
+    brief = obsidian_utils.build_context_brief(
+        str(vault), "claude-sessions", "claude-insights", PROJECT,
+        hook_status_line="[OK] test",
+    )
+
+    # Parse delimited sections.
+    def _section(label: str) -> str:
+        m = re.search(
+            rf"<<<{label}>>>\n(.*?)(?=\n<<<[A-Z_]+>>>|\Z)",
+            brief,
+            re.DOTALL,
+        )
+        assert m, f"missing section <<<{label}>>> in brief:\n{brief[:2000]}"
+        return m.group(1)
+
+    context_brief_section = _section("OB_CONTEXT_BRIEF")
+    load_manifest_section = _section("OB_LOAD_MANIFEST")
+    most_recent_path = _section("OB_MOST_RECENT_SESSION_PATH").strip()
+
+    # Extract the 6-digit HHMMSS tail from our snapshot's stem. The same
+    # value is used both (a) to match the nested `↳ HH:MM:SS` row in the
+    # context-brief table and (b) to match the `snapshot: [HHMMSS]` line in
+    # LOAD_MANIFEST. Tying both assertions to the SAME stem-derived value
+    # catches cross-session contamination that a shape-only regex would miss.
+    stem_hhmmss_match = re.search(r"-snapshot-(\d{6})$", snapshot_path.stem)
+    assert stem_hhmmss_match, (
+        f"snapshot stem missing trailing -snapshot-HHMMSS: {snapshot_path.stem}"
+    )
+    hhmmss = stem_hhmmss_match.group(1)  # e.g. "075610"
+    hhmmss_pretty = f"{hhmmss[:2]}:{hhmmss[2:4]}:{hhmmss[4:6]}"  # "07:56:10"
+
+    # Cross-midnight guard: build_context_brief() looks up snapshots via
+    # fetch_snapshot_summaries(note_date), which in turn calls
+    # find_snapshots_for_session() to glob `{date}-{slug}-*-snapshot*.md`.
+    # If Stage 1 (snapshot hook) and Stage 2 (session-log hook) straddle a
+    # calendar day boundary, the two files get different date prefixes and
+    # the snapshot is legitimately excluded from the session's lookup. Keep
+    # the strong assertions for the (overwhelmingly common) same-date case
+    # and avoid a wall-clock flake in the ~100ms-per-year straddle window.
+    snapshot_date_prefix = snapshot_path.stem.split("-snapshot-", 1)[0][:10]
+    session_date_prefix = session_path.stem[:10]
+    if snapshot_date_prefix == session_date_prefix:
+        # Nested snapshot row: exact `↳ HH:MM:SS` match against OUR snapshot's
+        # timestamp. Rendered inside a markdown table cell at
+        # obsidian_utils.py:1881 (`|   | ↳ {hhmmss_pretty} | ...`), so the
+        # glyph sits mid-cell after `|   | ` — no `^` line anchor.
+        assert f"↳ {hhmmss_pretty}" in context_brief_section, (
+            f"expected nested snapshot row `↳ {hhmmss_pretty}` in context brief:\n"
+            f"{context_brief_section[:2000]}"
+        )
+
+        assert re.search(
+            r"^snapshot_count:\s*1\b", load_manifest_section, re.MULTILINE
+        ), (
+            f"expected `snapshot_count: 1` in LOAD_MANIFEST:\n{load_manifest_section}"
+        )
+
+        # Producer at obsidian_utils.py:2091 emits
+        # `snapshot: [{hhmmss}] ({trigger}) {summary}` in build_context_brief's
+        # LOAD_MANIFEST composition — the full filename stem never appears on
+        # the line, only the HHMMSS tail. Match on that unique substring.
+        assert re.search(
+            rf"^snapshot:\s*\[{hhmmss}\]",
+            load_manifest_section,
+            re.MULTILINE,
+        ), (
+            f"expected `snapshot: [{hhmmss}]` line in LOAD_MANIFEST "
+            f"(stem={snapshot_path.stem}):\n{load_manifest_section}"
+        )
+    else:
+        # Straddled midnight — degraded assertion: just verify the snapshot
+        # still exists on disk (the production code path for cross-midnight
+        # is tracked as follow-up #68/#70 and is out of scope for this test).
+        assert snapshot_path.exists(), (
+            "snapshot note missing after cross-midnight straddle: "
+            f"snapshot_date={snapshot_date_prefix}, "
+            f"session_date={session_date_prefix}"
+        )
+
+    assert most_recent_path == str(session_path), (
+        f"expected MOST_RECENT_SESSION_PATH={session_path}, got={most_recent_path}"
+    )

--- a/plugins/obsidian-brain/tests/test_vault_doctor.py
+++ b/plugins/obsidian-brain/tests/test_vault_doctor.py
@@ -54,12 +54,14 @@ def test_cli_dry_run_reports_issues(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
@@ -106,12 +108,14 @@ def test_cli_apply_with_yes(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",

--- a/plugins/obsidian-brain/tests/test_vault_doctor_integration.py
+++ b/plugins/obsidian-brain/tests/test_vault_doctor_integration.py
@@ -23,7 +23,9 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # Two sessions on different days
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
 
     (cc_projects / "sid-a.jsonl").write_text(
         json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",
@@ -31,10 +33,10 @@ def test_end_to_end_scan_apply_verify(tmp_path):
     )
     os.utime(cc_projects / "sid-a.jsonl", (a_start + 3600, a_start + 3600))
     (cc_projects / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(cc_projects / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(cc_projects / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     # Session notes
     (vault / "claude-sessions" / "2026-04-09-proj1-aaaa.md").write_text(
@@ -124,3 +126,103 @@ def test_end_to_end_scan_apply_verify(tmp_path):
     )
     assert r.returncode == 0, f"re-scan exit: expected 0 (clean), got {r.returncode}: {r.stderr}"
     assert json.loads(r.stdout)["total_issues"] == 0
+
+
+def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
+    """Two stale insights converging on a single proposed sid must emit
+    convergence_warning=True and convergence_count>=2 at the top level of
+    each issue dict — alongside capture_signal and capture_confidence
+    (review C1, I6).
+    """
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    home = tmp_path
+    cc_projects = home / ".claude" / "projects" / "-Users-foo-convproj"
+    cc_projects.mkdir(parents=True)
+
+    # Session A: 2026-04-09 10:00 -> 11:00 (referenced by stale insights)
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    (cc_projects / "sid-a.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-a.jsonl", (a_end, a_end))
+
+    # Session B: 2026-04-10 10:00 -> 14:00 (the only candidate the date matcher
+    # can converge onto for both 2026-04-10 insights — they all collapse here)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    (cc_projects / "sid-b.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-b.jsonl", (b_end, b_end))
+
+    (vault / "claude-sessions" / "2026-04-09-convproj-aaaa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-09\nsession_id: sid-a\n"
+        "project: convproj\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+    (vault / "claude-sessions" / "2026-04-10-convproj-bbbb.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\n"
+        "project: convproj\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # Two stale insights on 2026-04-10 both pointing at sid-a — both will
+    # converge onto sid-b via the date-overlap matcher.
+    for slug in ("conv-one", "conv-two"):
+        insight = vault / "claude-insights" / f"2026-04-10-{slug}.md"
+        insight.write_text(
+            '---\n'
+            'type: claude-insight\n'
+            'date: 2026-04-10\n'
+            'source_session: sid-a\n'
+            'source_session_note: "[[2026-04-09-convproj-aaaa]]"\n'
+            'project: convproj\n'
+            'tags:\n'
+            '  - claude/insight\n'
+            '  - claude/project/convproj\n'
+            '---\n'
+            '\n'
+            '# body\n',
+            encoding="utf-8",
+        )
+        os.utime(insight, (b_start + 1800, b_start + 1800))
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["OBSIDIAN_BRAIN_VAULT"] = str(vault)
+    env["OBSIDIAN_BRAIN_SESSIONS_FOLDER"] = "claude-sessions"
+    env["OBSIDIAN_BRAIN_INSIGHTS_FOLDER"] = "claude-insights"
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    r = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+         "--project", "convproj", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"expected 1 (issues found), got {r.returncode}: {r.stderr}"
+    payload = json.loads(r.stdout)
+    issues = payload["issues"]
+    assert len(issues) >= 2, f"expected >=2 issues, got {len(issues)}: {issues}"
+
+    # Every issue must have all four keys at the TOP level (not under extra).
+    for issue in issues:
+        assert "capture_signal" in issue, f"missing capture_signal: {issue}"
+        assert "capture_confidence" in issue, f"missing capture_confidence: {issue}"
+        assert "convergence_warning" in issue, f"missing convergence_warning: {issue}"
+        assert "convergence_count" in issue, f"missing convergence_count: {issue}"
+
+    converged = [i for i in issues if i["convergence_warning"] is True]
+    assert len(converged) >= 2, (
+        f"expected >=2 issues with convergence_warning=True, got {len(converged)}: "
+        f"{[(i['note_path'], i['convergence_warning']) for i in issues]}"
+    )
+    for issue in converged:
+        assert issue["convergence_count"] >= 2, (
+            f"convergence_count must be >=2 when warned: {issue}"
+        )

--- a/plugins/obsidian-brain/tests/test_vault_doctor_snapshot_migration.py
+++ b/plugins/obsidian-brain/tests/test_vault_doctor_snapshot_migration.py
@@ -74,15 +74,28 @@ def test_missing_status_summarized_when_summary_exists(tmp_path):
 
 
 def test_missing_backlink_populates_source_session_note(tmp_path):
+    """Normal same-date case — parent resolves via sessions_by_id.
+
+    Uses an arbitrary (non-hash-based) parent filename to prove the
+    resolver is truly keyed on session_id frontmatter, not on a
+    filename shape that happens to match the old (date, slug, sid_hash)
+    composer. Under pre-#68 code, the fabricated stem
+    "2026-04-18-demo-<sha256('s4')[:4]>" would NOT match the actual
+    filename here — pre-#68 would emit unresolved=True, this test
+    would fail.
+    """
     sess = tmp_path / "claude-sessions"; sess.mkdir()
-    # Parent filename must match the computed stem: <date>-<slug(project)>-<sha256(sid)[:4]>
-    # For session_id="s4" the hash prefix is computed deterministically.
-    import hashlib as _h
     sid = "s4"
-    hash4 = _h.sha256(sid.encode()).hexdigest()[:4]
-    parent_stem = f"2026-04-18-demo-{hash4}"
-    _write_session(sess / f"{parent_stem}.md", session_id=sid)
-    p = sess / f"{parent_stem}-snapshot-110000.md"
+    # Non-hash filename — deliberately does not match the old
+    # (date, slug, sid_hash) composer output.
+    parent_stem = "2026-04-18-demo-parent"
+    (sess / f"{parent_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    # Snapshot filename also does not need to follow any specific scheme.
+    p = sess / "2026-04-18-demo-snap-110000.md"
     p.write_text(
         f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\nproject: demo\n"
         "trigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
@@ -91,13 +104,22 @@ def test_missing_backlink_populates_source_session_note(tmp_path):
     issues = snapshot_migration.scan(str(tmp_path), "claude-sessions", "claude-insights", 3650)
     miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
     assert len(miss) == 1
-    assert not miss[0].extra.get("unresolved")  # parent exists
+    assert not miss[0].extra.get("unresolved")  # parent resolved via session_id
+    assert miss[0].extra["parent_stem"] == parent_stem
     snapshot_migration.apply(miss, str(tmp_path / "backup"))
     text = p.read_text(encoding="utf-8")
     assert f'source_session_note: "[[{parent_stem}]]"' in text
 
 
 def test_missing_backlink_unresolved_when_parent_absent(tmp_path):
+    """Orphan snapshot (no session note matches session_id) -> unresolved.
+
+    Only the first two assertions (len==1, unresolved=True) held under
+    pre-#68 behavior; the three new assertions below (proposed_source=="",
+    confidence==0.0, reason contains "parent session not found") encode
+    tighter post-fix semantics that the old code — which fabricated a
+    speculative wikilink with confidence=0.3 — did not satisfy.
+    """
     sess = tmp_path / "claude-sessions"; sess.mkdir()
     p = sess / "2026-04-18-demo-zz-snapshot-110000.md"
     p.write_text(
@@ -109,6 +131,9 @@ def test_missing_backlink_unresolved_when_parent_absent(tmp_path):
     miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
     assert len(miss) == 1
     assert miss[0].extra.get("unresolved")
+    assert miss[0].proposed_source == ""
+    assert miss[0].confidence == 0.0
+    assert "parent session not found" in miss[0].reason
 
 
 def test_session_missing_snapshots_list_is_backfilled(tmp_path):
@@ -148,7 +173,10 @@ def test_wikilink_rewrite_across_vault_on_rename(tmp_path):
 def test_migration_is_idempotent(tmp_path):
     sess = tmp_path / "claude-sessions"; sess.mkdir()
     _write_legacy_snapshot(sess / "2026-04-18-demo-ee-snapshot.md", session_id="eeee")
-    # Parent stem must match hash of "eeee" since _write_legacy_snapshot hardcodes project="demo"
+    # The hash-based parent stem is vestigial — post-#68 the resolver
+    # matches on session_id in frontmatter, not on filename shape. Any
+    # filename carrying session_id="eeee" in frontmatter would work;
+    # this form preserves the pre-#68 fixture for minimal churn.
     import hashlib as _h
     hash4 = _h.sha256(b"eeee").hexdigest()[:4]
     _write_session(sess / f"2026-04-18-demo-{hash4}.md", session_id="eeee")
@@ -178,6 +206,27 @@ def test_missing_backlink_unresolved_when_sid_missing(tmp_path):
     # Apply should record unresolved status
     results = snapshot_migration.apply(miss, str(tmp_path / "backup"))
     assert results[0].status == "unresolved"
+
+
+def test_missing_backlink_unresolved_when_project_missing(tmp_path):
+    """No project in snapshot frontmatter -> unresolved.
+
+    Covers the second half of the `not sid or not proj` guard (the
+    sid-missing half is covered by test_missing_backlink_unresolved_when_sid_missing).
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    p = sess / "2026-04-18-demo-ff-snapshot-100000.md"
+    p.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: sid-abc\n"
+        "trigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(str(tmp_path), "claude-sessions", "claude-insights", 3650)
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1
+    assert miss[0].extra.get("unresolved")
+    assert "project" in miss[0].reason
+    assert "session_id" not in miss[0].reason
 
 
 def test_scan_returns_empty_when_sessions_folder_missing(tmp_path):
@@ -746,3 +795,311 @@ def test_no_rollback_after_partial_wikilink_rewrite(tmp_path, monkeypatch):
     # Result.note_path points at the surviving (renamed) file so the user
     # can locate it for manual review.
     assert results[0].note_path == str(new_path)
+
+
+def test_missing_backlink_cross_midnight_uses_session_id_index(tmp_path):
+    """Snapshot from before-midnight must backlink to after-midnight parent.
+
+    Regression for #68: §3 previously composed the parent stem from the
+    snapshot's own `date` field, which breaks when PreCompact fires on
+    day N and SessionEnd on day N+1. The parent is now resolved via
+    sessions_by_id keyed by session_id, which is stable across midnight.
+    """
+    import hashlib as _h
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "cross-midnight-sid"
+    hash4 = _h.sha256(sid.encode()).hexdigest()[:4]
+
+    # Parent session — dated the day AFTER the snapshot. Written inline
+    # (not via _write_session helper) so the frontmatter date matches
+    # the filename date — keeps this cross-midnight fixture internally
+    # consistent and self-documenting.
+    parent_stem = f"2026-04-10-demo-{hash4}"
+    (sess / f"{parent_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-10\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+
+    # Snapshot — dated the day BEFORE its parent session (cross-midnight)
+    snap = sess / f"2026-04-09-demo-{hash4}-snapshot-235959.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-09\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1
+    assert not miss[0].extra.get("unresolved")
+    assert miss[0].extra["parent_stem"] == parent_stem
+    # Proposal must reference the AFTER-midnight parent, not the snapshot's own date
+    assert f'source_session_note: "[[{parent_stem}]]"' in miss[0].proposed_source
+    assert "2026-04-09-demo-" not in miss[0].proposed_source
+
+    snapshot_migration.apply(miss, str(tmp_path / "backup"))
+    text = snap.read_text(encoding="utf-8")
+    assert f'source_session_note: "[[{parent_stem}]]"' in text
+
+
+# ----- Issue #81 regression tests: duplicate-sid collision handling -----
+
+
+def test_missing_backlink_ambiguous_when_duplicate_session_ids(tmp_path):
+    """When multiple session notes carry the same sid, ``sessions_by_id``
+    must not pick an arbitrary winner for backlink resolution. Instead,
+    scan() detects sid collisions while building the index and treats
+    snapshots with that sid as unresolved.
+
+    Expected behavior: emit an UNRESOLVED Issue for snapshots whose sid
+    is in the collision set — never a speculative
+    ``source_session_note`` wikilink. The reason string contains both
+    "ambiguous" (human-readable marker) and the full sid (greppable by
+    operators).
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "11111111-2222-3333-4444-555555555555"
+    # Two sessions sharing the same session_id on different dates.
+    # Write them directly (not via _write_session) so filename date
+    # matches frontmatter date per PR #80 review guidance.
+    (sess / "2026-04-15-demo-first.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S1\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-second.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S2\n",
+        encoding="utf-8",
+    )
+    # Snapshot missing source_session_note (the §3 trigger) with the colliding sid.
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1, f"expected exactly one snapshot-missing-backlink, got {miss}"
+    assert miss[0].extra.get("unresolved") is True, (
+        f"duplicate-sid snapshot must be unresolved, got extra={miss[0].extra}"
+    )
+    assert miss[0].proposed_source == "", (
+        f"must not fabricate a wikilink for ambiguous parent, got proposed_source={miss[0].proposed_source!r}"
+    )
+    assert miss[0].confidence == 0.0, (
+        f"ambiguous parent must have confidence=0.0, got {miss[0].confidence}"
+    )
+    assert "ambiguous" in miss[0].reason, (
+        f"reason must contain 'ambiguous', got: {miss[0].reason!r}"
+    )
+    assert sid in miss[0].reason, (
+        f"reason must contain the full sid {sid!r} for grep, got: {miss[0].reason!r}"
+    )
+
+    # §4 must NOT emit a session-missing-snapshots-list for the colliding sid
+    # (neither session can be declared the authoritative parent).
+    sess_miss = [i for i in issues if i.check == "session-missing-snapshots-list"]
+    for issue in sess_miss:
+        # If §4 fires, it must not be for either of the two colliding sessions.
+        assert not issue.note_path.endswith("2026-04-15-demo-first.md"), (
+            f"§4 must not emit for a colliding-sid session, got: {issue}"
+        )
+        assert not issue.note_path.endswith("2026-04-18-demo-second.md"), (
+            f"§4 must not emit for a colliding-sid session, got: {issue}"
+        )
+
+
+def test_missing_backlink_two_snapshots_sharing_session_id_both_resolve(tmp_path):
+    """Regression guard: two snapshots for ONE session (non-colliding) both backlink.
+
+    Simulates two PreCompact fires within a single session. The sid
+    points at a UNIQUE session (no collision) and both snapshots must
+    resolve via ``sessions_by_id`` with confidence 0.95 — the
+    collision-detection path must not over-trigger on the legitimate
+    "multiple snapshots per session" case.
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "unique-session-id-xyz"
+    parent_stem = "2026-04-18-demo-multi"
+    (sess / f"{parent_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    snap_a = sess / "2026-04-18-demo-multi-snap-100000.md"
+    snap_a.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap A\n",
+        encoding="utf-8",
+    )
+    snap_b = sess / "2026-04-18-demo-multi-snap-140000.md"
+    snap_b.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap B\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 2, (
+        f"expected two snapshot-missing-backlink (one per snapshot), got {len(miss)}: {miss}"
+    )
+    for issue in miss:
+        assert issue.extra.get("unresolved") is False, (
+            f"non-colliding sid must resolve, got extra={issue.extra}"
+        )
+        assert issue.extra.get("parent_stem") == parent_stem, (
+            f"parent_stem must be {parent_stem!r}, got {issue.extra.get('parent_stem')!r}"
+        )
+        assert issue.confidence == 0.95, (
+            f"non-colliding resolution must have confidence=0.95, got {issue.confidence}"
+        )
+
+
+# ----- Issue #81 follow-ups from PR #85 review -----
+
+
+def test_missing_backlink_cross_project_collision_detected_with_project_filter(tmp_path):
+    """Issue #81 second-order: --project=foo must NOT silently disarm
+    collision detection when colliding sessions span projects.
+
+    Scenario: one session in project ``demo`` and one in project
+    ``other`` share a session_id. The user runs ``scan(project="demo")``
+    expecting project-scoped issues. Without project-blind collision
+    detection, the ``other`` session gets filtered out at ingest, the
+    collision goes unregistered, and the demo snapshot's backlink falls
+    back to an arbitrary filesystem-order-dependent winner — resurrecting
+    exactly the bug this PR fixes, inside the filtered scan.
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "cross-proj-2222-3333-4444-555555555555"
+    (sess / "2026-04-15-demo-collide.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Demo session\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-other-collide.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: other\nstatus: summarized\n---\n\n# Other session\n",
+        encoding="utf-8",
+    )
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650, project="demo",
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1, f"expected one snapshot-missing-backlink, got {miss}"
+    assert miss[0].extra.get("unresolved") is True, (
+        f"cross-project collision must still be ambiguous under --project filter, "
+        f"got extra={miss[0].extra}"
+    )
+    assert "ambiguous" in miss[0].reason, (
+        f"reason must contain 'ambiguous', got: {miss[0].reason!r}"
+    )
+    assert sid in miss[0].reason, (
+        f"reason must contain the full sid for grep, got: {miss[0].reason!r}"
+    )
+
+
+def test_missing_backlink_three_way_sid_collision(tmp_path):
+    """Issue #81: three session notes sharing one sid all trigger the
+    ambiguous branch (guards against a future refactor that branches on
+    "first duplicate vs. nth duplicate").
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "three-way-aaaa-bbbb-cccc-dddddddddddd"
+    for n, date in enumerate(("2026-04-15", "2026-04-16", "2026-04-17"), start=1):
+        (sess / f"{date}-demo-s{n}.md").write_text(
+            f"---\ntype: claude-session\ndate: {date}\nsession_id: {sid}\n"
+            f"project: demo\nstatus: summarized\n---\n\n# S{n}\n",
+            encoding="utf-8",
+        )
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1, f"expected one snapshot-missing-backlink, got {miss}"
+    assert miss[0].extra.get("unresolved") is True
+    assert "ambiguous" in miss[0].reason
+    assert sid in miss[0].reason
+
+
+def test_missing_backlink_mixed_collision_and_unique_sids(tmp_path):
+    """Issue #81: collision filter is per-sid, not global. A scan with
+    both a colliding sid and a unique sid must flag the colliding
+    snapshot as ambiguous AND resolve the unique snapshot normally.
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid_collide = "mix-collide-aaaa-bbbb-cccc-dddddddddddd"
+    sid_unique = "mix-unique-1111-2222-3333-444444444444"
+    # Two sessions sharing sid_collide
+    (sess / "2026-04-15-demo-dup1.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid_collide}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Dup1\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-16-demo-dup2.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-16\nsession_id: {sid_collide}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Dup2\n",
+        encoding="utf-8",
+    )
+    # One session with sid_unique
+    unique_stem = "2026-04-17-demo-unique"
+    (sess / f"{unique_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-17\nsession_id: {sid_unique}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Unique\n",
+        encoding="utf-8",
+    )
+    # Snapshot for the colliding sid
+    snap_c = sess / "2026-04-18-demo-collide-snap-120000.md"
+    snap_c.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid_collide}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# SnapC\n",
+        encoding="utf-8",
+    )
+    # Snapshot for the unique sid
+    snap_u = sess / "2026-04-18-demo-unique-snap-120000.md"
+    snap_u.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid_unique}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# SnapU\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    by_path = {i.note_path: i for i in miss}
+    assert str(snap_c) in by_path and str(snap_u) in by_path, (
+        f"expected issues for both snapshots, got paths={list(by_path)}"
+    )
+    # Colliding snapshot → ambiguous/unresolved
+    ic = by_path[str(snap_c)]
+    assert ic.extra.get("unresolved") is True
+    assert "ambiguous" in ic.reason
+    assert sid_collide in ic.reason
+    # Unique snapshot → resolved with parent_stem
+    iu = by_path[str(snap_u)]
+    assert iu.extra.get("unresolved") is False, (
+        f"unique sid must resolve, got extra={iu.extra}"
+    )
+    assert iu.extra.get("parent_stem") == unique_stem
+    assert iu.confidence == 0.95

--- a/plugins/obsidian-brain/tests/test_vault_doctor_snapshots.py
+++ b/plugins/obsidian-brain/tests/test_vault_doctor_snapshots.py
@@ -574,3 +574,262 @@ def test_stale_apply_handles_unquoted_yaml_list_items(tmp_path):
     assert stale_stem not in fm
     # Live entry preserved
     assert "2026-04-18-demo-uu-snapshot-100000" in fm
+
+
+# ----- Issue #81 regression tests: duplicate-sid collision handling -----
+
+
+def test_snapshot_broken_backlink_ambiguous_when_duplicate_session_ids(tmp_path):
+    """Snapshots with duplicate candidate sessions for the same
+    ``session_id`` must be treated as unresolved rather than as having
+    a confidently broken backlink.
+
+    When multiple session notes share the same ``session_id``, the
+    checker cannot reliably determine which note a
+    ``source_session_note`` should reference. In that ambiguous case,
+    the snapshot is classified as a snapshot-orphan (unresolved), and
+    no ``snapshot-broken-backlink`` issue is emitted.
+    """
+    vault = tmp_path
+    sess = vault / "claude-sessions"; sess.mkdir()
+    sid = "11111111-2222-3333-4444-555555555555"
+    # Two sessions sharing the same session_id on different dates.
+    (sess / "2026-04-15-demo-first.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S1\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-second.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S2\n",
+        encoding="utf-8",
+    )
+    # Snapshot with source_session_note pointing at "something-that-could-match-either".
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        f'project: demo\ntrigger: compact\nstatus: summarized\n'
+        f'source_session_note: "[[something-that-could-match-either]]"\n---\n\n# Snap\n\n'
+        "## Summary\nbody\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_integrity.scan(
+        str(vault), "claude-sessions", "claude-insights", 30,
+    )
+    # Filter to issues for THIS snapshot (ignore session-list issues etc.)
+    snap_issues = [i for i in issues if i.note_path == str(snap)]
+    assert len(snap_issues) == 1, (
+        f"expected exactly one issue for the colliding snapshot, got {snap_issues}"
+    )
+    issue = snap_issues[0]
+    assert issue.check == "snapshot-orphan", (
+        f"colliding-sid snapshot must route to snapshot-orphan, got check={issue.check!r}"
+    )
+    assert issue.extra.get("unresolved") is True, (
+        f"ambiguous parent must be unresolved, got extra={issue.extra}"
+    )
+    assert "ambiguous" in issue.reason, (
+        f"reason must contain 'ambiguous', got: {issue.reason!r}"
+    )
+    assert sid in issue.reason, (
+        f"reason must contain the full sid {sid!r} for grep, got: {issue.reason!r}"
+    )
+    # Absolutely no snapshot-broken-backlink for this snapshot (would suggest
+    # a confidently-wrong parent).
+    broken = [i for i in issues
+              if i.check == "snapshot-broken-backlink" and i.note_path == str(snap)]
+    assert broken == [], (
+        f"colliding sid must NOT produce snapshot-broken-backlink, got: {broken}"
+    )
+    # Forward-consistency loop iterates sessions_by_id.items() and can
+    # emit session-snapshot-list-missing / session-snapshot-list-stale
+    # against either of the colliding session notes. Colliding sids
+    # must be excluded from that loop so neither session note receives
+    # a list-consistency issue triggered by this snapshot.
+    sess_paths = {
+        str(sess / "2026-04-15-demo-first.md"),
+        str(sess / "2026-04-18-demo-second.md"),
+    }
+    forward = [
+        i for i in issues
+        if i.check in ("session-snapshot-list-missing", "session-snapshot-list-stale")
+        and i.note_path in sess_paths
+    ]
+    assert forward == [], (
+        f"colliding-sid sessions must be skipped in forward-consistency loop, got: {forward}"
+    )
+
+
+# ----- Issue #81 follow-ups from PR #85 review -----
+
+
+def test_snapshot_broken_backlink_cross_project_collision_detected_with_project_filter(tmp_path):
+    """Issue #81 second-order: --project=foo must NOT silently disarm
+    collision detection when colliding sessions span projects. The
+    cross-project scenario is exactly the class vault-doctor is meant
+    to catch (project-rename migrations, re-imports), and without
+    project-blind collision detection the broken-backlink path would
+    emit a confident wrong fix inside the filtered scan.
+    """
+    vault = tmp_path
+    sess = vault / "claude-sessions"; sess.mkdir()
+    sid = "cross-proj-aaaa-bbbb-cccc-dddddddddddd"
+    (sess / "2026-04-15-demo-collide.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-other-collide.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: other\nstatus: summarized\n---\n\n# Other\n",
+        encoding="utf-8",
+    )
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        f'project: demo\ntrigger: compact\nstatus: summarized\n'
+        f'source_session_note: "[[2026-04-15-demo-collide]]"\n---\n\n# Snap\n\n'
+        "## Summary\nbody\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_integrity.scan(
+        str(vault), "claude-sessions", "claude-insights", 30, project="demo",
+    )
+    snap_issues = [i for i in issues if i.note_path == str(snap)]
+    assert len(snap_issues) == 1, (
+        f"expected exactly one issue for the cross-project colliding snapshot, got {snap_issues}"
+    )
+    issue = snap_issues[0]
+    assert issue.check == "snapshot-orphan", (
+        f"cross-project collision must route to snapshot-orphan, got check={issue.check!r}"
+    )
+    assert issue.extra.get("unresolved") is True
+    assert "ambiguous" in issue.reason
+    assert sid in issue.reason
+    broken = [i for i in issues
+              if i.check == "snapshot-broken-backlink" and i.note_path == str(snap)]
+    assert broken == [], (
+        f"cross-project colliding sid must NOT produce snapshot-broken-backlink, got: {broken}"
+    )
+
+
+def test_snapshot_broken_backlink_three_way_sid_collision(tmp_path):
+    """Issue #81: three session notes sharing one sid all route the
+    snapshot to ambiguous orphan (refactor guard — ensures the filter
+    is triggered on the nth duplicate, not only the second).
+    """
+    vault = tmp_path
+    sess = vault / "claude-sessions"; sess.mkdir()
+    sid = "three-way-aaaa-bbbb-cccc-dddddddddddd"
+    for n, date in enumerate(("2026-04-15", "2026-04-16", "2026-04-17"), start=1):
+        (sess / f"{date}-demo-s{n}.md").write_text(
+            f"---\ntype: claude-session\ndate: {date}\nsession_id: {sid}\n"
+            f"project: demo\nstatus: summarized\n---\n\n# S{n}\n",
+            encoding="utf-8",
+        )
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\n"
+        f'project: demo\ntrigger: compact\nstatus: summarized\n'
+        f'source_session_note: "[[2026-04-15-demo-s1]]"\n---\n\n# Snap\n\n'
+        "## Summary\nbody\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_integrity.scan(
+        str(vault), "claude-sessions", "claude-insights", 30,
+    )
+    snap_issues = [i for i in issues if i.note_path == str(snap)]
+    assert len(snap_issues) == 1
+    assert snap_issues[0].check == "snapshot-orphan"
+    assert snap_issues[0].extra.get("unresolved") is True
+    assert "ambiguous" in snap_issues[0].reason
+    assert sid in snap_issues[0].reason
+
+
+def test_snapshot_broken_backlink_mixed_collision_and_unique_sids(tmp_path):
+    """Issue #81: collision filter is per-sid — a scan with one
+    colliding and one unique sid must ambiguate the colliding snapshot
+    while still resolving the unique snapshot normally (no
+    snapshot-broken-backlink if its wikilink matches the unique parent).
+    """
+    vault = tmp_path
+    sess = vault / "claude-sessions"; sess.mkdir()
+    sid_collide = "mix-collide-aaaa-bbbb-cccc-dddddddddddd"
+    sid_unique = "mix-unique-1111-2222-3333-444444444444"
+    (sess / "2026-04-15-demo-dup1.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-15\nsession_id: {sid_collide}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Dup1\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-16-demo-dup2.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-16\nsession_id: {sid_collide}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Dup2\n",
+        encoding="utf-8",
+    )
+    unique_stem = "2026-04-17-demo-unique"
+    (sess / f"{unique_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-17\nsession_id: {sid_unique}\n"
+        "project: demo\nstatus: summarized\n---\n\n# Unique\n",
+        encoding="utf-8",
+    )
+    snap_c = sess / "2026-04-18-demo-collide-snap-120000.md"
+    snap_c.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid_collide}\n"
+        f'project: demo\ntrigger: compact\nstatus: summarized\n'
+        f'source_session_note: "[[2026-04-15-demo-dup1]]"\n---\n\n# SnapC\n\n'
+        "## Summary\nbody\n",
+        encoding="utf-8",
+    )
+    snap_u = sess / "2026-04-18-demo-unique-snap-120000.md"
+    snap_u.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid_unique}\n"
+        f'project: demo\ntrigger: compact\nstatus: summarized\n'
+        f'source_session_note: "[[{unique_stem}]]"\n---\n\n# SnapU\n\n'
+        "## Summary\nbody\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_integrity.scan(
+        str(vault), "claude-sessions", "claude-insights", 30,
+    )
+    # Colliding snapshot → ambiguous orphan, no broken-backlink
+    snap_c_issues = [i for i in issues if i.note_path == str(snap_c)]
+    assert len(snap_c_issues) == 1
+    assert snap_c_issues[0].check == "snapshot-orphan"
+    assert snap_c_issues[0].extra.get("unresolved") is True
+    assert "ambiguous" in snap_c_issues[0].reason
+    # Unique snapshot → no issues (wikilink matches parent stem)
+    snap_u_issues = [i for i in issues if i.note_path == str(snap_u)]
+    assert snap_u_issues == [], (
+        f"unique-sid snapshot with correct backlink must produce no issues, got: {snap_u_issues}"
+    )
+
+
+def test_snapshot_orphan_empty_session_id_emits_specific_reason(tmp_path):
+    """Parity with snapshot_migration.py §3: a snapshot with no
+    session_id in frontmatter must get a specific reason, not the
+    generic 'no session note matches this session_id' (which would
+    interpolate an empty sid and confuse operators).
+    """
+    vault = tmp_path
+    sess = vault / "claude-sessions"; sess.mkdir()
+    snap = sess / "2026-04-18-demo-snap-120000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_integrity.scan(
+        str(vault), "claude-sessions", "claude-insights", 30,
+    )
+    snap_issues = [i for i in issues if i.note_path == str(snap)]
+    # Expect exactly one snapshot-orphan with the specific empty-sid reason.
+    orphans = [i for i in snap_issues if i.check == "snapshot-orphan"]
+    assert len(orphans) == 1, f"expected one snapshot-orphan, got {orphans}"
+    assert orphans[0].extra.get("unresolved") is True
+    assert "no session_id" in orphans[0].reason, (
+        f"reason must explicitly name the missing field, got: {orphans[0].reason!r}"
+    )
+    # The generic missing-parent reason must NOT be used (would interpolate empty sid).
+    assert "no session note on disk matches" not in orphans[0].reason, (
+        f"empty-sid must get specific reason, not the generic missing-parent reason, got: {orphans[0].reason!r}"
+    )

--- a/plugins/obsidian-brain/tests/test_vault_doctor_source_sessions.py
+++ b/plugins/obsidian-brain/tests/test_vault_doctor_source_sessions.py
@@ -5,12 +5,15 @@ import json
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 _SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import vault_doctor_checks.source_sessions as ss  # noqa: E402 (must follow sys.path setup)
 
 
 @pytest.fixture
@@ -94,13 +97,14 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
 
-    # Session B: 2026-04-10 14:00–15:00
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
-    b_end = b_start + 3600
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_end)
+    # Session B: 2026-04-10 10:00–14:00 (window must contain midday for the
+    # date-based capture_time match under the fix for issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_end)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured 2026-04-10 14:30 but wrongly stamped with sid-a
+    # Insight captured 2026-04-10 10:30 but wrongly stamped with sid-a
     insight_mtime = b_start + 1800
     _write_insight(
         v / "claude-insights",
@@ -179,7 +183,13 @@ def test_scan_honors_days_window(doctor_vault, monkeypatch):
 
 
 def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch):
-    """Insight whose mtime does not fall inside any session window → UNRESOLVED (or not flagged)."""
+    """Insight whose date has no overlapping session window → UNRESOLVED.
+
+    Under day-overlap matching, the matcher finds any session whose JSONL
+    window touches the note's calendar day. To produce an unresolved case we
+    need the only session to be on a *different* calendar day so no overlap
+    exists at all.
+    """
     import vault_doctor_checks.source_sessions as check
 
     v = doctor_vault["vault"]
@@ -187,11 +197,13 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    a_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
-    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_start + 3600)
-    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
+    # Session on 2026-04-09 only — no session on 2026-04-10
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
+    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
 
-    # Insight captured at 20:00 — no session window covers it, and current source 'wrong-sid' isn't a real session
+    # Insight dated 2026-04-10 — day-overlap finds no session whose window
+    # touches 2026-04-10, so the result is unresolved.
     gap_mtime = calendar.timegm(time.strptime("2026-04-10 20:00", "%Y-%m-%d %H:%M"))
     _write_insight(
         v / "claude-insights",
@@ -222,9 +234,11 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     monkeypatch.setenv("HOME", str(home))
 
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_start + 4 * 3600)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
@@ -350,6 +364,42 @@ def test_apply_errors_on_missing_proposed_sid(doctor_vault, tmp_path):
     assert note.read_text(encoding="utf-8") == original
 
 
+def test_parse_date_midpoint_valid_date_returns_noon_utc():
+    ts = ss._parse_date_midpoint("2026-04-21")
+    assert ts is not None
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+    assert (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second) == (
+        2026, 4, 21, 12, 0, 0,
+    )
+
+
+def test_parse_date_midpoint_empty_returns_none():
+    assert ss._parse_date_midpoint("") is None
+
+
+def test_parse_date_midpoint_malformed_returns_none():
+    assert ss._parse_date_midpoint("not-a-date") is None
+    assert ss._parse_date_midpoint("2026-13-99") is None
+
+
+@pytest.mark.parametrize(
+    "bad_date",
+    [
+        "2025-02-29",  # not a leap year
+        "2026-13-01",  # invalid month
+        "2026-04-31",  # April has 30 days
+        "",            # empty
+        "not-a-date",  # garbage
+        "2026/04/21",  # wrong separator
+        "20260421",    # no separators
+    ],
+)
+def test_parse_date_midpoint_negative_edges_return_none(bad_date):
+    """T5: invalid date strings must return None so capture-time signal
+    falls back to the next preference rather than fabricating a timestamp."""
+    assert ss._parse_date_midpoint(bad_date) is None
+
+
 def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     """When two session windows both contain capture_time, latest first_ts wins."""
     import vault_doctor_checks.source_sessions as check
@@ -371,9 +421,11 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_mtime)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured at 14:02 — inside BOTH windows
+    # Insight captured at 14:02 — inside BOTH windows.
+    # We inject created_at so _capture_time uses the precise sub-day timestamp
+    # (date: midday = 12:00, which only falls in A; we need 14:02 in both).
     insight_mtime = calendar.timegm(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
-    _write_insight(
+    insight_path = _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "boundary-tie-insight",
@@ -382,6 +434,13 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
         "2026-04-10-proj1-aaaa",
         insight_mtime,
     )
+    # Inject created_at so _capture_time resolves to 14:02 (inside both windows)
+    # rather than midday-12:00 (which only falls in session A). (issue #93)
+    text = insight_path.read_text(encoding="utf-8")
+    text = text.replace("type: claude-insight\n",
+                        "type: claude-insight\ncreated_at: 2026-04-10T14:02:00Z\n")
+    insight_path.write_text(text, encoding="utf-8")
+    os.utime(insight_path, (insight_mtime, insight_mtime))  # restore mtime after write
 
     issues = check.scan(
         str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
@@ -448,10 +507,9 @@ def test_jsonl_dir_for_project_picks_newest_worktree(tmp_path, monkeypatch):
 def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     """After apply, the patched note's mtime equals its pre-apply mtime.
 
-    This is load-bearing: scan() uses note mtime as capture_time. If apply
-    updated mtime to 'now', a subsequent scan would match the note's new
-    mtime against the current session's window, not the original capture
-    session — re-flagging every fixed note on every run.
+    scan() uses mtime for the --days cutoff filter. If apply updated mtime
+    to 'now', notes written long ago could accidentally re-enter the scan
+    window after being fixed. Preserving mtime prevents that drift.
     """
     import vault_doctor_checks.source_sessions as check
     import os
@@ -463,13 +521,15 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
 
     import calendar, time
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_start + 4 * 3600)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    original_mtime = b_start + 1800  # 2026-04-10 14:30
+    original_mtime = b_start + 1800  # 2026-04-10 10:30
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
@@ -627,3 +687,1411 @@ def test_safe_project_slug_sanitizes_dots_and_separators():
     assert check._safe_project_slug("") == "unknown"
     assert check._safe_project_slug("...") == "unknown"
     assert check._safe_project_slug("valid-name_1") == "valid-name_1"
+
+
+def test_capture_time_prefers_created_at(tmp_path):
+    note = tmp_path / "2026-01-01-foo.md"
+    note.write_text("body")
+    fm = {"created_at": "2026-04-21T14:33:02+00:00", "date": "2026-03-15"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (1.0, "created_at")
+    expected = datetime.fromisoformat("2026-04-21T14:33:02+00:00").timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_date(tmp_path):
+    note = tmp_path / "1999-12-31-foo.md"
+    note.write_text("body")
+    fm = {"date": "2026-04-21"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.9, "date")
+    expected = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_filename(tmp_path):
+    note = tmp_path / "2026-04-21-foo-bar.md"
+    note.write_text("body")
+    fm = {}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.85, "filename")
+    expected = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_mtime(tmp_path):
+    note = tmp_path / "no-date-prefix.md"
+    note.write_text("body")
+    fixed_mtime = 1_700_000_000.0
+    os.utime(note, (fixed_mtime, fixed_mtime))
+    fm = {}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.5, "mtime")
+    assert abs(ts - fixed_mtime) < 0.001
+
+
+def test_capture_time_malformed_date_falls_through(tmp_path):
+    """Malformed date in frontmatter must not block the chain."""
+    note = tmp_path / "2026-04-21-foo.md"
+    note.write_text("body")
+    fm = {"date": "garbage"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.85, "filename")
+
+
+def test_scan_ignores_mtime_when_date_present(doctor_vault, monkeypatch):
+    """A note whose mtime drifted into a later session's window must NOT be flagged
+    when its frontmatter date and filename prefix point to the original session's day."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day_a = "2026-04-21"
+    day_b = "2026-04-22"
+    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    # Session A: 2026-04-21, 10:00–18:00 UTC
+    ts_a_start = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    ts_a_end = datetime(2026, 4, 21, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
+                 datetime.fromtimestamp(ts_a_start, tz=timezone.utc).isoformat(),
+                 ts_a_end)
+
+    # Session B: 2026-04-22, 09:00–17:00 UTC
+    ts_b_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    ts_b_end = datetime(2026, 4, 22, 17, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
+                 datetime.fromtimestamp(ts_b_start, tz=timezone.utc).isoformat(),
+                 ts_b_end)
+
+    sess_a = _write_session_note(vault / "claude-sessions", day_a, project, sid_a, "1111")
+    sess_b = _write_session_note(vault / "claude-sessions", day_b, project, sid_b, "2222")
+
+    # Insight written on day A but mtime drifted to day B (e.g., /check-items touched it)
+    insight = _write_insight(
+        vault / "claude-insights",
+        day_a,
+        "real-capture-day-a",
+        project,
+        sid_a,
+        sess_a.stem,
+        ts_b_start + 3600,  # mtime fell into session B's window
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,  # large window so test stays valid as wall-clock advances
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: drifted mtime caused false-positive flag despite date: pointing to session A"
+    )
+
+
+def test_scan_emits_capture_signal_and_confidence(doctor_vault, monkeypatch):
+    """Issue.extra must include capture_signal and capture_confidence so the
+    skill report can flag low-confidence matches to the operator."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    sid_correct = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    sid_wrong = "wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww"
+
+    ts_start = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    ts_end = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_correct}.jsonl",
+                 datetime.fromtimestamp(ts_start, tz=timezone.utc).isoformat(),
+                 ts_end)
+    # A different session whose window will be the *current* (wrong) source
+    other_start = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc).timestamp()
+    other_end = datetime(2026, 4, 20, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_wrong}.jsonl",
+                 datetime.fromtimestamp(other_start, tz=timezone.utc).isoformat(),
+                 other_end)
+
+    sess_correct = _write_session_note(vault / "claude-sessions", day, project, sid_correct, "1234")
+    _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid_wrong, "5678")
+
+    insight = _write_insight(
+        vault / "claude-insights",
+        date=day,
+        slug="signal-test",
+        project=project,
+        src_sid=sid_wrong,
+        src_note_basename=f"2026-04-20-{project}-5678",
+        mtime=ts_start + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, "expected the wrong-source note to be flagged"
+    assert flagged[0].extra.get("capture_signal") == "date"
+    assert flagged[0].extra.get("capture_confidence") == 0.9
+    assert flagged[0].extra.get("proposed_sid") == sid_correct
+
+
+def test_scan_unresolved_reason_uses_capture_time(doctor_vault, monkeypatch):
+    """Unresolved-branch reason string must mention capture_time (not mtime)
+    and surface signal/conf in extra. (issue #93)"""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    # One session, but its window is far from any plausible capture-time of the
+    # insight. Insight's source_session does not match any session in the index,
+    # so the unresolved branch fires.
+    sid_only = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    s_start = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_end = datetime(2026, 1, 1, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_only}.jsonl",
+                 datetime.fromtimestamp(s_start, tz=timezone.utc).isoformat(),
+                 s_end)
+    _write_session_note(vault / "claude-sessions", "2026-01-01", project, sid_only, "ffff")
+
+    # Note dated far from any session, source_session not in idx
+    insight_mtime = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp()
+    _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="unresolved-signal",
+        project=project,
+        src_sid="not-a-real-sid",
+        src_note_basename="2026-04-22-bogus",
+        mtime=insight_mtime,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    unresolved = [i for i in issues if i.extra.get("unresolved") is True]
+    assert len(unresolved) == 1, f"expected 1 unresolved issue, got {len(unresolved)}"
+    iss = unresolved[0]
+    assert "capture_time" in iss.reason, f"reason should mention capture_time: {iss.reason!r}"
+    assert "mtime" not in iss.reason, f"reason should not mention mtime: {iss.reason!r}"
+    assert iss.extra.get("capture_signal") == "date"
+    assert iss.extra.get("capture_confidence") == 0.9
+
+
+def test_scan_trusts_current_source_when_same_day(doctor_vault, monkeypatch):
+    """If the existing source_session resolves to a same-day session note in
+    the index, the check must NOT re-match — even when the matcher would
+    otherwise propose a different same-day session."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    # Two same-day sessions, arranged so capture_time at 12:00 UTC (date midday)
+    # falls only inside Y. Without early-exit the matcher would propose Y;
+    # with early-exit, current source X is trusted.
+    sid_x = "11111111-1111-1111-1111-111111111111"
+    sid_y = "22222222-2222-2222-2222-222222222222"
+
+    # Session X: 2026-04-22 09:00–11:00 (current source — does NOT contain 12:00)
+    x_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    x_end = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_start, tz=timezone.utc).isoformat(),
+                 x_end)
+
+    # Session Y: 2026-04-22 12:00–18:00 (contains 12:00 — matcher would pick this)
+    y_start = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp()
+    y_end = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_start, tz=timezone.utc).isoformat(),
+                 y_end)
+
+    sess_x = _write_session_note(vault / "claude-sessions", day, project, sid_x, "xxxx")
+    _write_session_note(vault / "claude-sessions", day, project, sid_y, "yyyy")
+
+    # Insight whose date: is day; source_session points at X (correct). With
+    # capture_time at 12:00 UTC the matcher would otherwise propose Y. mtime
+    # is irrelevant for this test (the new check no longer uses it for
+    # matching) but we set it to a known value for stability.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date=day,
+        slug="trust-x",
+        project=project,
+        src_sid=sid_x,
+        src_note_basename=sess_x.stem,
+        mtime=y_start + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: same-day source was second-guessed by the matcher"
+    )
+
+
+def test_scan_created_at_bypasses_early_exit(doctor_vault, monkeypatch):
+    """Pin test for the capture_signal != 'created_at' carve-out in Phase 1b
+    early-exit (issue #93). A note with created_at AND a same-day current
+    source MUST still be validated by the matcher; the early-exit must NOT
+    short-circuit just because date strings agree.
+
+    If this test goes silent (passes when it shouldn't), the carve-out has
+    been removed and high-precision created_at notes are being trusted on
+    same-day SID match alone — masking actual corruption."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    sid_x = "33333333-3333-3333-3333-333333333333"
+    sid_y = "44444444-4444-4444-4444-444444444444"
+
+    # Two same-day sessions, NON-overlapping.
+    # Session X: 09:00–11:00 (current source — INCORRECT for the note).
+    # Session Y: 14:00–16:00 (the note's actual created_at falls here).
+    x_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    x_end = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_start, tz=timezone.utc).isoformat(),
+                 x_end)
+
+    y_start = datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc).timestamp()
+    y_end = datetime(2026, 4, 22, 16, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_start, tz=timezone.utc).isoformat(),
+                 y_end)
+
+    sess_x = _write_session_note(vault / "claude-sessions", day, project, sid_x, "3333")
+    sess_y = _write_session_note(vault / "claude-sessions", day, project, sid_y, "4444")
+
+    # Insight: source_session is X (same day, would satisfy date-equality early-exit
+    # if signal were date/filename), but created_at = 14:30 falls in Y's window.
+    # The matcher MUST be allowed to run and propose Y. Early-exit must NOT fire.
+    insight_path = vault / "claude-insights" / f"{day}-pin-carveout.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: {day}\n"
+        f"created_at: 2026-04-22T14:30:00+00:00\n"
+        f"source_session: {sid_x}\n"
+        f'source_session_note: "[[{sess_x.stem}]]"\n'
+        f"project: {project}\n"
+        f"tags:\n"
+        f"  - claude/insight\n"
+        f"  - claude/project/{project}\n"
+        f"---\n"
+        f"# pin\n",
+        encoding="utf-8",
+    )
+    # Set mtime to a known stable value (irrelevant for matching now)
+    import os as _os
+    _os.utime(insight_path, (y_start + 1800, y_start + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1, (
+        "carve-out regression: created_at note with same-day current source "
+        "was not re-validated by matcher (early-exit fired when it should not)"
+    )
+    iss = flagged[0]
+    assert iss.extra.get("capture_signal") == "created_at"
+    assert iss.extra.get("proposed_sid") == sid_y, (
+        f"matcher should propose Y (where created_at falls), got {iss.extra.get('proposed_sid')!r}"
+    )
+
+
+def test_scan_uuid_first_lookup_across_projects(doctor_vault, monkeypatch):
+    """Phase 1b looks up source_session UUID across all projects, not just
+    the note's declared project. Insight notes from a worktree-launched skill
+    may have project=A while their actual source session has project=A--worktree-slug.
+    The UUID is globally unique; the cross-project lookup must trust it."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    project = doctor_vault["project"]  # "proj1"
+    monkeypatch.setenv("HOME", str(home))
+
+    # Create a worktree-style adjacent project's JSONL dir
+    worktree_jsonl_dir = home / ".claude" / "projects" / "-Users-foo-proj1--worktree"
+    worktree_jsonl_dir.mkdir(parents=True)
+
+    sid_w = "77777777-7777-7777-7777-777777777777"
+    w_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    w_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(worktree_jsonl_dir / f"{sid_w}.jsonl",
+                 datetime.fromtimestamp(w_first, tz=timezone.utc).isoformat(),
+                 w_last)
+
+    # Session note records project=proj1--worktree (the worktree's name)
+    sess = vault / "claude-sessions" / "2026-04-22-proj1-worktree-7777.md"
+    sess.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-22\n"
+        f"session_id: {sid_w}\n"
+        "project: proj1--worktree\n"
+        "status: summarized\n"
+        "---\n"
+        "# Session\n## Summary\nstub\n",
+        encoding="utf-8",
+    )
+
+    # Insight has project=proj1 (declared from main-repo cwd) but its source
+    # session was in a worktree (project=proj1--worktree). Without UUID-first
+    # cross-project lookup, this would be flagged as stale.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="cross-project-uuid",
+        project=project,  # "proj1"
+        src_sid=sid_w,
+        src_note_basename=sess.stem,
+        mtime=w_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: cross-project UUID resolution failed; insight flagged "
+        "despite source UUID resolving to a real session note"
+    )
+
+
+def test_scan_basename_only_repair_when_uuid_resolves(doctor_vault, monkeypatch):
+    """When the source_session UUID resolves correctly but the basename in
+    source_session_note is stale (e.g., un-truncated worktree slug vs
+    truncated actual filename), propose a basename-only repair. UUID stays."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid = "88888888-8888-8888-8888-888888888888"
+    s_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+
+    # Session note exists with truncated basename
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid, "8888")
+
+    # Insight records a STALE (un-truncated) basename in source_session_note
+    insight_path = vault / "claude-insights" / "2026-04-22-basename-repair.md"
+    stale_basename = "2026-04-22-proj1-some-very-long-original-name-that-was-truncated-8888"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[{stale_basename}]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    import os as _os
+    _os.utime(insight_path, (s_first + 1800, s_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1, "expected basename-mismatch flag"
+    iss = flagged[0]
+    assert iss.extra.get("basename_only") is True
+    assert iss.extra.get("proposed_sid") == sid  # UUID unchanged
+    assert sess.stem in iss.proposed_source  # actual basename in proposal
+    assert iss.confidence >= 0.95
+
+
+def test_scan_caps_date_signal_confidence(doctor_vault, monkeypatch):
+    """Matcher-proposed flags using only date/filename signals must be capped
+    at confidence <= 0.6 -- multi-session days collapse onto noon-UTC and
+    produce uniform-but-wrong proposals."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa11"
+    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb11"
+
+    a_first = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    a_last = datetime(2026, 4, 21, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
+                 datetime.fromtimestamp(a_first, tz=timezone.utc).isoformat(),
+                 a_last)
+    b_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    b_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
+                 datetime.fromtimestamp(b_first, tz=timezone.utc).isoformat(),
+                 b_last)
+
+    _write_session_note(vault / "claude-sessions", "2026-04-21", project, sid_a, "1111")
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_b, "2222")
+
+    # Insight on day B (sole same-day session) but source_session points to
+    # day-A session whose UUID does NOT resolve (no entry in idx for proj1)
+    bogus_sid = "00000000-0000-0000-0000-000000000000"
+    _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="conf-cap",
+        project=project,
+        src_sid=bogus_sid,
+        src_note_basename="2026-04-22-bogus",
+        mtime=b_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if "conf-cap" in i.note_path and not i.extra.get("unresolved")]
+    assert len(flagged) == 1
+    assert flagged[0].confidence <= 0.6
+
+
+@pytest.mark.parametrize("n_flags", [2, 3, 5])
+def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch, n_flags):
+    """When N>=2 flags in a project converge on the same proposed session,
+    confidence drops to <= 0.4 and convergence_warning is set, with
+    convergence_count == N (review T3)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # One real session whose window contains noon on the day notes claim
+    sid_real = "cccccccc-cccc-cccc-cccc-cccccccccc11"
+    r_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    r_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_real}.jsonl",
+                 datetime.fromtimestamp(r_first, tz=timezone.utc).isoformat(),
+                 r_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "real")
+
+    # N insights with bogus UUIDs that don't resolve -> matcher proposes sid_real for all
+    for n in range(n_flags):
+        slug = f"converge-{n+1}"
+        # Distinct bogus UUIDs ensure the global SID index doesn't resolve them,
+        # which forces the day-overlap matcher to propose sid_real for each.
+        bogus = f"{n+1:08d}-1111-1111-1111-{n+1:012d}"
+        _write_insight(
+            vault / "claude-insights",
+            date="2026-04-22",
+            slug=slug,
+            project=project,
+            src_sid=bogus,
+            src_note_basename="2026-04-22-bogus",
+            mtime=r_first + 1800,
+        )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if "converge" in i.note_path and i.extra.get("proposed_sid") == sid_real]
+    assert len(flagged) == n_flags, f"expected {n_flags} convergence flags, got {len(flagged)}"
+    for i in flagged:
+        assert i.extra.get("convergence_warning") is True, (
+            f"expected convergence_warning on {i.note_path}"
+        )
+        assert i.extra.get("convergence_count") == n_flags
+        assert i.confidence <= 0.4
+
+
+def test_scan_trusts_cross_midnight_source(doctor_vault, monkeypatch):
+    """Phase 1b extension (issue #93): a session that started the night before
+    note.date and ran into note.date is the legitimate cross-midnight case.
+    The current source must be trusted even though session_note.date != note.date."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    # Cross-midnight session: started 2026-04-20 22:00, ended 2026-04-21 03:00
+    sid_x = "55555555-5555-5555-5555-555555555555"
+    x_first = datetime(2026, 4, 20, 22, 0, tzinfo=timezone.utc).timestamp()
+    x_last = datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_first, tz=timezone.utc).isoformat(),
+                 x_last)
+
+    # Another session, same project, fully within 2026-04-21 daytime
+    sid_y = "66666666-6666-6666-6666-666666666666"
+    y_first = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    y_last = datetime(2026, 4, 21, 14, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_first, tz=timezone.utc).isoformat(),
+                 y_last)
+
+    # Session note for X has date 2026-04-20 (its first-entry day)
+    sess_x = _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid_x, "5555")
+    sess_y = _write_session_note(vault / "claude-sessions", "2026-04-21", project, sid_y, "6666")
+
+    # Insight dated 2026-04-21 (calendar day of capture), source_session = X
+    # (the session that crossed midnight). Without the JSONL-overlap extension,
+    # session.date "2026-04-20" != note.date "2026-04-21" → Phase 1b doesn't fire,
+    # matcher proposes Y → false positive.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-21",
+        slug="cross-midnight-trust",
+        project=project,
+        src_sid=sid_x,
+        src_note_basename=sess_x.stem,
+        mtime=y_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: cross-midnight session_note.date=note.date-1 not trusted "
+        "(session window overlaps note's calendar day → should be trusted)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 1 — snapshot type filter
+# ---------------------------------------------------------------------------
+
+def test_list_all_session_notes_filters_out_snapshots(doctor_vault):
+    """Snapshot notes share session_id with parents; only sessions get indexed."""
+    vault = doctor_vault["vault"]
+    sessions = vault / "claude-sessions"
+    sid = "11111111-1111-1111-1111-111111111111"
+
+    # Parent session note
+    parent = sessions / "2026-04-21-proj1-1111.md"
+    parent.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# session\n",
+        encoding="utf-8",
+    )
+    # Snapshot note with the same SID — must NOT clobber parent in idx
+    snap = sessions / "2026-04-21-proj1-1111-snapshot-131103.md"
+    snap.write_text(
+        "---\n"
+        "type: claude-snapshot\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# snap\n",
+        encoding="utf-8",
+    )
+
+    idx = ss._list_all_session_notes(sessions)
+    assert sid in idx
+    assert idx[sid]["basename"] == "2026-04-21-proj1-1111", (
+        f"snapshot clobbered parent: got {idx[sid]['basename']!r}"
+    )
+
+
+def test_list_session_notes_filters_out_snapshots(doctor_vault):
+    """Project-scoped variant must also skip snapshot type."""
+    vault = doctor_vault["vault"]
+    sessions = vault / "claude-sessions"
+    sid = "22222222-2222-2222-2222-222222222222"
+
+    parent = sessions / "2026-04-21-proj1-2222.md"
+    parent.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# session\n",
+        encoding="utf-8",
+    )
+    snap = sessions / "2026-04-21-proj1-2222-snapshot-090000.md"
+    snap.write_text(
+        "---\n"
+        "type: claude-snapshot\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# snap\n",
+        encoding="utf-8",
+    )
+
+    idx = ss._list_session_notes(sessions, "proj1")
+    assert idx[sid]["basename"] == "2026-04-21-proj1-2222"
+
+
+def test_list_all_session_notes_warns_and_keeps_first_on_duplicate_sid(
+    tmp_path, capsys
+):
+    """Copilot R5: when two session notes share the same session_id (a known
+    possible vault state — vault-import collision, rename gone wrong, etc.),
+    the helper iterates in sorted order so the winner is deterministic and
+    emits a stderr warning instead of silently overwriting.
+    """
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    sid = "deadbeef-dead-beef-dead-deadbeefdead"
+    # Note A sorts before Note B lexically — A should win.
+    (sessions / "2026-04-26-aaa-proj1-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: proj1\nstatus: summarized\n---\n# A\n",
+        encoding="utf-8",
+    )
+    (sessions / "2026-04-26-bbb-proj1-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: proj1\nstatus: summarized\n---\n# B\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()  # drain
+    idx = ss._list_all_session_notes(sessions)
+    assert sid in idx
+    assert idx[sid]["basename"] == "2026-04-26-aaa-proj1-collide", (
+        f"sorted-order winner should be the lexically-first file, got {idx[sid]['basename']}"
+    )
+    captured = capsys.readouterr()
+    assert "duplicate session_id" in captured.err
+    assert "deadbeef" in captured.err  # short SID prefix
+    assert "rename one to disambiguate" in captured.err
+
+
+def test_list_session_notes_warns_and_keeps_first_on_duplicate_sid(
+    tmp_path, capsys
+):
+    """Copilot R5: parity-symmetry — _list_session_notes must also iterate
+    deterministically and warn on duplicate SIDs."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    sid = "feedface-feed-face-feed-feedfacefeed"
+    (sessions / "2026-04-26-bbb-projP-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: projP\nstatus: summarized\n---\n# B\n",
+        encoding="utf-8",
+    )
+    (sessions / "2026-04-26-aaa-projP-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: projP\nstatus: summarized\n---\n# A\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+    idx = ss._list_session_notes(sessions, "projP")
+    assert idx[sid]["basename"] == "2026-04-26-aaa-projP-collide"
+    captured = capsys.readouterr()
+    assert "duplicate session_id" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 2 — trust UUID when JSONL exists but session note is missing
+# ---------------------------------------------------------------------------
+
+def test_scan_trusts_uuid_when_jsonl_exists_but_note_missing(doctor_vault, monkeypatch):
+    """When source_session UUID has a real JSONL but no session note, the
+    UUID is still authoritative — refuse to propose a different-session
+    rewrite. (Reference: issue #93 + #98 interaction.)"""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_orphan = "33333333-3333-3333-3333-333333333333"
+    o_first = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    o_last = datetime(2026, 4, 22, 22, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_orphan}.jsonl",
+                 datetime.fromtimestamp(o_first, tz=timezone.utc).isoformat(),
+                 o_last)
+    # NOTE: No session note written for sid_orphan — simulates SessionEnd hook miss
+
+    # A different real session whose window also overlaps the day —
+    # without the fix, the matcher would propose this as the "correct" target.
+    sid_distractor = "44444444-4444-4444-4444-444444444444"
+    d_first = datetime(2026, 4, 22, 12, 30, tzinfo=timezone.utc).timestamp()
+    d_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_distractor}.jsonl",
+                 datetime.fromtimestamp(d_first, tz=timezone.utc).isoformat(),
+                 d_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_distractor, "dist")
+
+    # Insight whose source_session is the orphan UUID
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="orphan-uuid-trust",
+        project=project,
+        src_sid=sid_orphan,
+        src_note_basename="2026-04-22-proj1-orph",
+        mtime=o_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, (
+        f"expected exactly 1 issue for orphan-UUID insight, got {len(flagged)}"
+    )
+    assert flagged[0].extra.get("unresolved") is True
+    assert flagged[0].extra.get("missing_session_note") is True
+    assert flagged[0].extra.get("proposed_sid") != sid_distractor, (
+        "regression: must not propose a different session when source UUID "
+        "had a real JSONL (just missing session note)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 3 — day-overlap matcher for date-precision signals
+# ---------------------------------------------------------------------------
+
+def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
+    """Sessions that ended before noon UTC must still be candidates for
+    notes whose date matches the calendar day. Old noon-anchor matcher
+    excluded them; day-overlap matcher includes them by overlap size."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Morning session: 08:00 → 11:05 UTC (ended before noon)
+    sid_morning = "55555555-5555-5555-5555-555555555555"
+    m_first = datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc).timestamp()
+    m_last = datetime(2026, 4, 24, 11, 5, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_morning}.jsonl",
+                 datetime.fromtimestamp(m_first, tz=timezone.utc).isoformat(),
+                 m_last)
+    sess_m = _write_session_note(vault / "claude-sessions", "2026-04-24", project, sid_morning, "morn")
+
+    # Noon-anchored session: 12:30 → 14:00 — what the old matcher would have picked
+    sid_noon = "66666666-6666-6666-6666-666666666666"
+    n_first = datetime(2026, 4, 24, 12, 30, tzinfo=timezone.utc).timestamp()
+    n_last = datetime(2026, 4, 24, 14, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_noon}.jsonl",
+                 datetime.fromtimestamp(n_first, tz=timezone.utc).isoformat(),
+                 n_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-24", project, sid_noon, "noon")
+
+    # Insight on 2026-04-24 with a non-resolving source_session UUID and no
+    # JSONL anywhere — falls through to the matcher. Morning session has
+    # the larger overlap (185 minutes vs 90 minutes), so day-overlap picks it.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-24",
+        slug="morning-session",
+        project=project,
+        src_sid="00000000-0000-0000-0000-000000000099",
+        src_note_basename="2026-04-24-bogus",
+        mtime=m_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight) and not i.extra.get("unresolved")]
+    assert len(flagged) == 1, (
+        f"expected exactly one non-unresolved issue for {insight}, got {len(flagged)}: {flagged}"
+    )
+    # Day-overlap matcher should pick the morning session (larger overlap)
+    assert flagged[0].extra.get("proposed_sid") == sid_morning, (
+        f"day-overlap matcher should prefer morning session ({sid_morning}) "
+        f"over noon session ({sid_noon}); got {flagged[0].extra.get('proposed_sid')}"
+    )
+
+
+def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault, monkeypatch):
+    """When capture_signal falls all the way to mtime (no created_at, no date
+    frontmatter, no YYYY-MM-DD filename prefix), the proposed-rewrite confidence
+    must be capped at <=0.3 — below the convergence floor of 0.4 — so an
+    operator never auto-applies an mtime-only proposal (review C2)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Two sessions on different days so the date-overlap matcher returns a
+    # different session than the one currently referenced.
+    a_start = calendar.timegm(time.strptime("2026-04-15 10:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-15T10:00:00Z", a_end)
+    _write_session_note(vault / "claude-sessions", "2026-04-15", project, "sid-a", "aaaa")
+
+    b_start = calendar.timegm(time.strptime("2026-04-16 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-16T10:00:00Z", b_end)
+    _write_session_note(vault / "claude-sessions", "2026-04-16", project, "sid-b", "bbbb")
+
+    # Insight with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename
+    # prefix → mtime is the only available signal. Filename intentionally
+    # avoids the date prefix.
+    insight = vault / "claude-insights" / "no-date-prefix-mtime-only.md"
+    insight.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        f"source_session: sid-a\n"
+        f'source_session_note: "[[2026-04-15-{project}-aaaa]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        f"  - claude/project/{project}\n"
+        "---\n"
+        "# body\n",
+        encoding="utf-8",
+    )
+    # Set mtime inside session B's window so the matcher proposes sid-b.
+    insight_mtime = b_start + 1800
+    os.utime(insight, (insight_mtime, insight_mtime))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [
+        i for i in issues
+        if i.note_path == str(insight)
+        and not i.extra.get("unresolved")
+        and not i.extra.get("basename_only")
+    ]
+    assert len(flagged) == 1, (
+        f"expected 1 stale flag for mtime-signal insight, got {len(flagged)}: "
+        f"{[(i.confidence, i.extra) for i in flagged]}"
+    )
+    assert flagged[0].extra.get("capture_signal") == "mtime", (
+        f"test setup error: expected mtime signal, got {flagged[0].extra.get('capture_signal')}"
+    )
+    assert flagged[0].confidence <= 0.3, (
+        f"mtime-signal confidence must be <=0.3, got {flagged[0].confidence}"
+    )
+
+
+def test_scan_emits_unresolved_when_jsonl_exists_but_session_note_missing(
+    doctor_vault, monkeypatch
+):
+    """When source_session UUID has a real JSONL but no vault session note,
+    emit an unresolved diagnostic Issue surfacing the coverage gap. UUID
+    remains authoritative — never propose a different-session rewrite
+    (review C3)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_orphan = "55555555-5555-5555-5555-555555555555"
+    o_first = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    o_last = datetime(2026, 4, 22, 22, 0, tzinfo=timezone.utc).timestamp()
+    orphan_jsonl = jsonl_dir / f"{sid_orphan}.jsonl"
+    _write_jsonl(
+        orphan_jsonl,
+        datetime.fromtimestamp(o_first, tz=timezone.utc).isoformat(),
+        o_last,
+    )
+    # NOTE: deliberately NO session note for sid_orphan — coverage gap.
+
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="orphan-uuid-c3",
+        project=project,
+        src_sid=sid_orphan,
+        src_note_basename="2026-04-22-proj1-orph",
+        mtime=o_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, (
+        f"expected exactly 1 issue for orphan-UUID insight, got {len(flagged)}"
+    )
+    issue = flagged[0]
+    assert issue.extra.get("unresolved") is True
+    assert issue.extra.get("missing_session_note") is True
+    assert issue.extra.get("jsonl_path") == str(orphan_jsonl)
+    assert issue.confidence == 0.0
+
+
+def test_list_all_session_notes_warns_on_malformed_frontmatter(tmp_path, capsys):
+    """A `.md` file that opens with `---` but whose frontmatter fails to parse
+    should be skipped AND warned about on stderr — operators need a signal
+    that something is wrong with that note (review C5)."""
+    sessions_dir = tmp_path / "claude-sessions"
+    sessions_dir.mkdir()
+    bad = sessions_dir / "2026-04-22-malformed.md"
+    # Frontmatter block opens with --- but has no closing --- on its own line:
+    # _parse_frontmatter regex returns {} (no match), and the file starts with
+    # "---", so the malformed-warning branch fires.
+    bad.write_text("---\nfoo: bar\nno closing block here\n", encoding="utf-8")
+
+    out = ss._list_all_session_notes(sessions_dir)
+    captured = capsys.readouterr()
+    assert out == {}, f"expected empty dict for malformed-only dir, got {out}"
+    assert "[vault_doctor] malformed frontmatter, skipped:" in captured.err
+    assert "2026-04-22-malformed.md" in captured.err
+
+
+def test_phase_1b_fallback_via_find_jsonl_anywhere(tmp_path, monkeypatch):
+    """Phase 1b's session-window lookup must fall back to _find_jsonl_anywhere
+    when the session-note's worktree-suffixed `project:` does not resolve via
+    `_jsonl_dir_for_project`. Without the fix, the date matcher proposes a
+    different (canonical-project) session as a stale rewrite (review I4)."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    # Single canonical project dir under HOME=tmp_path. Both JSONLs live here
+    # (worktrees share parent-repo CC project dir), but the session-NOTE for
+    # sid_correct claims a worktree-suffixed `project:` value that won't
+    # resolve via _jsonl_dir_for_project.
+    canonical_dir = tmp_path / ".claude" / "projects" / "-Users-foo-obsidian-brain"
+    canonical_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Day used for note + sessions
+    day_start = calendar.timegm(time.strptime("2026-04-20 00:00", "%Y-%m-%d %H:%M"))
+
+    # sid_correct: window covers most of the day; session note claims
+    # worktree-suffixed project name
+    sid_correct = "11111111-1111-1111-1111-111111111111"
+    correct_first = day_start + 9 * 3600
+    correct_last = day_start + 18 * 3600
+    _write_jsonl(
+        canonical_dir / f"{sid_correct}.jsonl",
+        datetime.fromtimestamp(correct_first, tz=timezone.utc).isoformat(),
+        correct_last,
+    )
+    correct_note = vault / "claude-sessions" / "2026-04-20-obsidian-brain-corr.md"
+    correct_note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-20\n"
+        f"session_id: {sid_correct}\n"
+        # Worktree-suffixed project — _jsonl_dir_for_project misses this.
+        "project: obsidian-brain--issue-81-slug\n"
+        "status: summarized\n"
+        "---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # sid_wrong: also on 2026-04-20; session note claims canonical project.
+    # Without the fix, the date matcher (operating in canonical project's idx)
+    # picks this as the "correct" target, producing a stale-flag false positive.
+    sid_wrong = "22222222-2222-2222-2222-222222222222"
+    wrong_first = day_start + 8 * 3600
+    wrong_last = day_start + 19 * 3600
+    _write_jsonl(
+        canonical_dir / f"{sid_wrong}.jsonl",
+        datetime.fromtimestamp(wrong_first, tz=timezone.utc).isoformat(),
+        wrong_last,
+    )
+    (vault / "claude-sessions" / "2026-04-20-obsidian-brain-wrng.md").write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-20\n"
+        f"session_id: {sid_wrong}\n"
+        "project: obsidian-brain\n"
+        "status: summarized\n"
+        "---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # Insight: project=obsidian-brain (canonical), source_session=sid_correct,
+    # source_session_note=basename of sid_correct's note.
+    insight = vault / "claude-insights" / "2026-04-20-i4-fallback.md"
+    insight.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-20\n"
+        f"source_session: {sid_correct}\n"
+        'source_session_note: "[[2026-04-20-obsidian-brain-corr]]"\n'
+        "project: obsidian-brain\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        "  - claude/project/obsidian-brain\n"
+        "---\n# body\n",
+        encoding="utf-8",
+    )
+    insight_mtime = day_start + 12 * 3600
+    os.utime(insight, (insight_mtime, insight_mtime))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project="obsidian-brain",
+    )
+    flagged_stale = [
+        i for i in issues
+        if i.note_path == str(insight)
+        and not i.extra.get("unresolved")
+        and not i.extra.get("basename_only")
+    ]
+    assert flagged_stale == [], (
+        f"Phase 1b fallback failed: matcher proposed a wrong-session rewrite "
+        f"despite sid_correct having a real JSONL. Flagged: "
+        f"{[(i.proposed_source, i.extra) for i in flagged_stale]}"
+    )
+
+
+def test_find_jsonl_anywhere_returns_first_lexicographic_match(tmp_path, monkeypatch):
+    """T1: _find_jsonl_anywhere globs across all CC project dirs and returns
+    the first match by sorted order. UUIDs are globally unique, but if the
+    same SID file appears under two project dirs (e.g., a worktree that was
+    later moved or test fixtures), the result must be deterministic across
+    runs — sorted() ensures identical-input → identical-output."""
+    proj_a = tmp_path / ".claude" / "projects" / "-Users-foo-projA"
+    proj_b = tmp_path / ".claude" / "projects" / "-Users-foo-projB"
+    proj_a.mkdir(parents=True)
+    proj_b.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    sid = "11111111-1111-1111-1111-111111111111"
+    (proj_a / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+    (proj_b / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+
+    found = ss._find_jsonl_anywhere(sid)
+    assert found is not None
+    # sorted() returns lexicographically-first match — projA before projB
+    assert "projA" in str(found), f"expected projA winner, got {found}"
+
+    # Stability across repeated calls: sorted() is a total order on str
+    found2 = ss._find_jsonl_anywhere(sid)
+    assert found == found2
+
+
+def test_find_jsonl_anywhere_returns_none_when_missing(tmp_path, monkeypatch):
+    """T1: _find_jsonl_anywhere returns None when no project dir contains
+    a JSONL with the given SID."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude" / "projects" / "-Users-foo-projX").mkdir(parents=True)
+    assert ss._find_jsonl_anywhere("99999999-9999-9999-9999-999999999999") is None
+
+
+def test_find_jsonl_anywhere_uses_cache(tmp_path, monkeypatch):
+    """Copilot R3: per-scan cache amortizes glob cost when scan() looks up the
+    same UUID multiple times across notes (or both Phase 1b paths)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sid = "deadbeef-dead-beef-dead-deadbeefdead"
+    cc = tmp_path / ".claude" / "projects" / "-Users-foo-projC"
+    cc.mkdir(parents=True)
+    (cc / f"{sid}.jsonl").write_text("{}\n")
+
+    cache: dict[str, ss.Path | None] = {}
+    first = ss._find_jsonl_anywhere(sid, cache=cache)
+    assert first is not None
+    assert sid in cache and cache[sid] == first
+
+    # Now break globbing — if cache works, lookup still succeeds.
+    monkeypatch.setattr(ss.glob, "glob", lambda pattern: [])
+    second = ss._find_jsonl_anywhere(sid, cache=cache)
+    assert second == first, "cache hit must short-circuit the glob"
+
+    # Negative cache: a missing SID is also memoized.
+    miss_sid = "11111111-1111-1111-1111-111111111111"
+    missed = ss._find_jsonl_anywhere(miss_sid, cache=cache)
+    assert missed is None
+    assert miss_sid in cache and cache[miss_sid] is None
+
+
+def test_scan_reason_text_branches_by_signal(doctor_vault, monkeypatch):
+    """Copilot R3: day-precision matches (date/filename signal) describe a
+    calendar-day overlap; created_at matches describe a point-in-window match.
+    Reason strings must reflect the actual matcher used.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # date-signal: insight has frontmatter `date:` only. Day-overlap matcher fires.
+    sid_date_target = "33333333-3333-3333-3333-333333333333"
+    d_first = datetime(2026, 4, 22, 8, 0, tzinfo=timezone.utc).timestamp()
+    d_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_date_target}.jsonl",
+        datetime.fromtimestamp(d_first, tz=timezone.utc).isoformat(),
+        d_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-22", project, sid_date_target, "dtgt"
+    )
+
+    insight_date = vault / "claude-insights" / "2026-04-22-date-signal.md"
+    insight_date.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-22\n"
+        "source_session: 00000000-0000-0000-0000-000000000088\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# d\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_date, (d_first + 3600, d_first + 3600))
+
+    # created_at-signal: insight has frontmatter `created_at:`. Point matcher fires.
+    sid_ca_target = "44444444-4444-4444-4444-444444444444"
+    c_first = datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc).timestamp()
+    c_last = datetime(2026, 4, 23, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_ca_target}.jsonl",
+        datetime.fromtimestamp(c_first, tz=timezone.utc).isoformat(),
+        c_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-23", project, sid_ca_target, "ctgt"
+    )
+
+    insight_ca = vault / "claude-insights" / "2026-04-23-ca-signal.md"
+    insight_ca.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "created_at: 2026-04-23T10:30:00+00:00\n"
+        "source_session: 00000000-0000-0000-0000-000000000077\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# c\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_ca, (c_first + 1800, c_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+
+    date_issue = next(i for i in issues if i.note_path == str(insight_date))
+    assert "calendar day" in date_issue.reason, (
+        f"date-signal reason should describe calendar-day overlap, got: {date_issue.reason}"
+    )
+    assert "overlaps session" in date_issue.reason
+
+    ca_issue = next(i for i in issues if i.note_path == str(insight_ca))
+    assert "capture_time" in ca_issue.reason, (
+        f"created_at-signal reason should describe capture_time, got: {ca_issue.reason}"
+    )
+    assert "matches session" in ca_issue.reason and "window" in ca_issue.reason
+
+
+def test_scan_reason_text_for_mtime_fallback_uses_point_in_window(
+    doctor_vault, monkeypatch
+):
+    """Copilot R4-1: when capture_signal is 'mtime' AND there's no fm.date
+    AND no YYYY-MM-DD filename prefix, scan() falls through to the point-in-
+    window matcher (not day-overlap). Reason text must say 'capture_time
+    matches session window' not 'calendar day overlaps session window'.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_target = "55555555-5555-5555-5555-555555555555"
+    t_first = datetime(2026, 4, 24, 10, 0, tzinfo=timezone.utc).timestamp()
+    t_last = datetime(2026, 4, 24, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_target}.jsonl",
+        datetime.fromtimestamp(t_first, tz=timezone.utc).isoformat(),
+        t_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-24", project, sid_target, "tgt5"
+    )
+
+    # Note with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename prefix.
+    # Filename is intentionally non-date-prefixed.
+    note = vault / "claude-insights" / "mtime-only-no-date-no-filename.md"
+    note.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "source_session: 00000000-0000-0000-0000-000000000055\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# m\n",
+        encoding="utf-8",
+    )
+    os.utime(note, (t_first + 1800, t_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(note)]
+    assert flagged, "mtime-only note should flag (mtime falls inside window)"
+    issue = flagged[0]
+    assert issue.extra.get("capture_signal") == "mtime"
+    assert "capture_time" in issue.reason, (
+        f"mtime fallback uses point-in-window matcher; reason should say "
+        f"'capture_time' not 'calendar day'. Got: {issue.reason}"
+    )
+    assert "calendar day" not in issue.reason, (
+        f"mtime-fallback reason must not claim calendar-day overlap. Got: {issue.reason}"
+    )
+
+
+def test_convergence_guard_excludes_created_at_signal(doctor_vault, monkeypatch):
+    """Copilot R4-2: created_at signal uses point-in-window matching with
+    sub-day precision. Two legitimate stale insights from the same session
+    sharing a proposal target is normal — not heuristic collapse — so they
+    must NOT be capped to 0.4 by the convergence guard.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_target = "66666666-6666-6666-6666-666666666666"
+    t_first = datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc).timestamp()
+    t_last = datetime(2026, 4, 25, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_target}.jsonl",
+        datetime.fromtimestamp(t_first, tz=timezone.utc).isoformat(),
+        t_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-25", project, sid_target, "tgt6"
+    )
+
+    # Two insights with created_at signal both stale-pointing at a missing UUID.
+    # Both will be matched to sid_target (point-in-window). Without the R4-2
+    # fix, the convergence guard would cap both to 0.4 — a false positive.
+    for slug, ts in (("alpha", "2026-04-25T10:00:00+00:00"),
+                     ("beta", "2026-04-25T11:30:00+00:00")):
+        n = vault / "claude-insights" / f"created-at-conv-{slug}.md"
+        n.write_text(
+            "---\n"
+            "type: claude-insight\n"
+            f"created_at: {ts}\n"
+            "source_session: 00000000-0000-0000-0000-000000000066\n"
+            'source_session_note: "[[bogus]]"\n'
+            f"project: {project}\n"
+            "tags:\n"
+            f"  - claude/insight\n"
+            "---\n# x\n",
+            encoding="utf-8",
+        )
+        os.utime(n, (t_first + 3600, t_first + 3600))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    created_at_flags = [
+        i for i in issues
+        if i.extra.get("capture_signal") == "created_at"
+        and i.extra.get("proposed_sid") == sid_target
+    ]
+    assert len(created_at_flags) == 2, (
+        f"expected exactly 2 created_at flags converging on {sid_target}, "
+        f"got {len(created_at_flags)}"
+    )
+    for issue in created_at_flags:
+        assert issue.confidence == 0.95, (
+            f"created_at-signal flag must keep its 0.95 confidence — "
+            f"convergence guard should not cap created_at. Got: {issue.confidence}"
+        )
+        assert not issue.extra.get("convergence_warning"), (
+            f"convergence_warning must be False for created_at flags. "
+            f"Got: {issue.extra}"
+        )


### PR DESCRIPTION
## Summary

Monorepo release v3.7.0 — sync obsidian-brain v2.4.2 (8 fixes since v2.4.1).

obsidian-brain v2.4.2 was just released to <https://github.com/abhattacherjee/obsidian-brain/releases/tag/v2.4.2>. This PR mirrors the v2.4.2 tagged content into `plugins/obsidian-brain/` and bumps the monorepo to v3.7.0.

## Scope

| Issue | Area | Summary |
|---|---|---|
| #105 | hooks | Insight savers no longer stamp `source_session: unknown` after worktree deletion |
| #101 + #86 + #110 | hooks | Source-session backlinks stable across cross-midnight, worktree, and resumed sessions |
| #93 + 8 follow-ups | vault-doctor | source-sessions check uses immutable signal chain instead of mtime |
| #81 | vault-doctor | Detects duplicate session_id collisions |
| #50 | tests | E2E snapshot → /recall integration test |
| #68 | vault-doctor | Cross-midnight backlink resolution via session_id index |
| #45 | /compress | Rank-gap delta-score guard fixes same-topic peer rejection |
| #78 | /recall | N=1 picker fix + Skip-all sentinel |

## Changes

- 35 files modified in `plugins/obsidian-brain/`
- Root `.claude-plugin/marketplace.json` obsidian-brain entry: 2.4.1 → 2.4.2
- Monorepo `CHANGELOG.md`: new `[3.7.0]` entry

## Post-merge

- Tag `v3.7.0` on main
- Create GitHub release for monorepo v3.7.0

## Test plan

- [x] obsidian-brain v2.4.2 released independently and verified (812 pytest passing on source repo)
- [x] Sync exported from v2.4.2 git tag (not develop)
- [x] No `.github/`, `.claude/`, `__pycache__`, or other infra dirs leaked into the plugin folder
- [x] obsidian-brain `plugin.json` shows version 2.4.2 (not 2.4.3 dev-cycle)
- [x] Root `marketplace.json` obsidian-brain entry version updated
- [x] No unrelated plugin or skill content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
