### PR TITLE
docs: refresh README (current skills & plugins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Plugins bundle skills, commands, agents, and hooks into a single installable pac
 | [context-shield](./plugins/context-shield/) | 1.3.0 | 1 | 0 | Prevents context window overflow by delegating token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed. Covers: documentation sites, code audits, dependency research, large PR reviews, competitive analysis, security advisories. |
 | [custom-statusline](./plugins/custom-statusline/) | 1.3.0 | 1 | 0 | 4-tier adaptive statusline with icons for folder, git branch, and context usage |
 | [figma-ui-designer](./plugins/figma-ui-designer/) | 3.1.0 | 1 | 0 | Interactive Figma UI design skill with brainstorming, progress tracking, and design-to-code bridging via Figma MCP |
-| [git-flow](./plugins/git-flow/) | 2.0.0 | 1 | 5 | Git Flow branching workflow with slash commands and diagnostic tools |
-| [obsidian-brain](./plugins/obsidian-brain/) | 2.4.0 | 17 | 0 | Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata. |
+| [obsidian-brain](./plugins/obsidian-brain/) | 2.5.1 | 18 | 0 | Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata. |
 | [product-video-creation](./plugins/product-video-creation/) | 2.0.0 | 1 | 0 | Creates polished, narrated product demo videos using Remotion with AI-crafted storytelling, real app screenshots, animated phone mockups, brand-aligned styling, TTS voiceover, and background music. |
 | [skill-authoring](./plugins/skill-authoring/) | 2.3.0 | 1 | 0 | Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism |
 | [skill-publishing](./plugins/skill-publishing/) | 4.0.0 | 1 | 0 | Plugin-first publishing for Claude Code skills. Auto-assembles and syncs plugins from plugin-manifest.json files. Also supports bare skills and individual repos |
@@ -36,6 +35,8 @@ Plugins bundle skills, commands, agents, and hooks into a single installable pac
 | [spec-creator](./plugins/spec-creator/) | 2.3.0 | 1 | 0 | Creates detailed story specifications with TDD implementation steps, success metrics, Figma UX design gates, and vertical splitting from various inputs (plans, requirements, GitHub issues). |
 | [spec-review](./plugins/spec-review/) | 2.1.0 | 1 | 0 | Reviews and enriches story specifications with codebase-verified sub-tasks, architecture alignment, design simplification, and API test plans. |
 | [statusline-creator](./plugins/statusline-creator/) | 1.0.0 | 1 | 0 | Creates and customizes Claude Code statusline scripts from composable items |
+
+> **Note:** The `git-flow` plugin moved to its own repository — install via `/plugin marketplace add abhattacherjee/git-flow`.
 
 
 ### Install via Claude Code (Recommended)
@@ -141,4 +142,4 @@ These skills follow the **Agent Skills** standard — a `SKILL.md` file with YAM
 [MIT](LICENSE)
 
 ---
-*Last synced: 2026-04-16*
+*Last synced: 2026-06-01*


### PR DESCRIPTION
Brings README.md in line with the actual repo state (verified against on-disk `SKILL.md` frontmatter, `plugins/*/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`).

## Changes
- **Removed** the stale `git-flow` plugin row — it was extracted to its own repo (`abhattacherjee/git-flow`) and no longer exists in this monorepo. Added a relocation note below the table.
- **obsidian-brain**: `2.4.0` → `2.5.1`, skills `17` → `18`.
- **Last synced** date `2026-04-16` → `2026-06-01`.
- Plugins table now lists exactly 12 plugins, all matching disk + marketplace.json.

Skills table (7 skills) verified accurate — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)