### PR TITLE
release: v3.11.0

### DIFF
--- a/.claude/hooks/prevent-direct-push.py
+++ b/.claude/hooks/prevent-direct-push.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+PreToolUse Hook: Prevent Direct Push to Protected Branches
+
+Blocks git push to main/develop. Allows Git Flow operations,
+tag pushes, and feature branch pushes.
+
+Installed by /harden-repo into target repo's .claude/hooks/
+"""
+import json
+import os
+import re
+import sys
+import subprocess
+
+try:
+    input_data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Security gate must fail closed, not open
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "Push hook received invalid input. Blocking as a safety measure."
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+tool_name = input_data.get("tool_name", "")
+tool_input = input_data.get("tool_input", {})
+command = tool_input.get("command", "")
+
+# Only validate git push commands
+if tool_name != "Bash" or "git push" not in command:
+    sys.exit(0)
+
+# --- Project-scope guard ---
+# Skip this hook if the command targets a repo outside this project.
+# Hooks run in their own process (cwd = project dir), so git commands in
+# the hook inspect the wrong repo when Claude does "cd /other/repo && git push".
+def _targets_this_project(cmd: str) -> bool:
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return True  # Can't determine scope, be safe
+
+    project_dir = os.path.realpath(project_dir)
+
+    # Extract the first "cd /path" from the command (handles "cd X && git push")
+    cd_match = re.search(r'(?:^|[;&|]\s*)cd\s+("([^"]+)"|\'([^\']+)\'|(\S+))', cmd)
+    if cd_match:
+        target = cd_match.group(2) or cd_match.group(3) or cd_match.group(4)
+        target = os.path.expanduser(target)
+        target = os.path.expandvars(target)
+        target = os.path.realpath(target)
+        return os.path.commonpath([target, project_dir]) == project_dir
+
+    # No cd in command — assume it targets the project repo
+    return True
+
+if not _targets_this_project(command):
+    sys.exit(0)
+
+# Allow tag pushes — but only if not also targeting a protected branch.
+# Parse non-flag words after 'git push' to detect branch targets like 'main' or 'develop',
+# including refspecs like 'HEAD:main' or mixed commands like 'git push --tags origin main'.
+is_tag_push = ("refs/tags/" in command or "--tags" in command or
+               re.search(r'git push\s+\S+\s+v\d+\.\d+\.\d+', command))
+push_args = command.split("git push", 1)[-1] if "git push" in command else ""
+push_words = [w for w in push_args.split() if not w.startswith("-")]
+targets_protected_branch = any(
+    w in ("main", "develop") or w.endswith(":main") or w.endswith(":develop")
+    for w in push_words
+)
+if is_tag_push and not targets_protected_branch:
+    sys.exit(0)
+
+# Allow branch deletion (--delete) for release/hotfix cleanup
+if "--delete" in command and ("release/" in command or "hotfix/" in command):
+    sys.exit(0)
+
+# Get current branch
+try:
+    current_branch = subprocess.check_output(
+        ["git", "branch", "--show-current"],
+        stderr=subprocess.DEVNULL,
+        text=True
+    ).strip()
+except (subprocess.CalledProcessError, FileNotFoundError):
+    current_branch = ""
+    # If we can't determine the branch and the push doesn't specify an explicit remote+ref,
+    # fail closed to prevent accidental pushes to protected branches
+    if not re.search(r'git push\s+\S+\s+\S+', command) and not any(x in command for x in ["refs/", "--delete", "--tags"]):
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "Cannot determine current branch. Specify target explicitly: git push origin <branch>"
+            }
+        }
+        print(json.dumps(output))
+        sys.exit(0)
+
+# Also fail-closed for detached HEAD (empty branch name from successful command)
+if not current_branch and not re.search(r'git push\s+\S+\s+\S+', command) and not any(x in command for x in ["refs/", "--delete", "--tags"]):
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "Cannot determine current branch (detached HEAD?). Specify target explicitly: git push origin <branch>"
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+# Allow Git Flow finish operations
+# Release/hotfix branches push to both main and develop
+is_release_or_hotfix_finish = (
+    current_branch.startswith("release/") or
+    current_branch.startswith("hotfix/")
+)
+
+if is_release_or_hotfix_finish:
+    sys.exit(0)
+
+# Git Flow finish: on main or develop, HEAD is a merge from a Git Flow branch
+if current_branch in ["main", "develop"]:
+    try:
+        # Check if HEAD is a merge commit (has 2+ parents)
+        subprocess.check_output(
+            ["git", "rev-parse", "HEAD^2"],
+            stderr=subprocess.DEVNULL,
+            text=True
+        )
+        # Check if the merge message references a Git Flow branch
+        merge_msg = subprocess.check_output(
+            ["git", "log", "-1", "--format=%s", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
+        # main: only release/hotfix merges (features never merge to main)
+        # develop: feature/release/hotfix merges + main sync
+        if current_branch == "main":
+            allowed = ["release/", "hotfix/"]
+        else:
+            allowed = ["feature/", "release/", "hotfix/", "Merge main into develop"]
+        if any(pattern in merge_msg for pattern in allowed):
+            sys.exit(0)
+    except subprocess.CalledProcessError:
+        # HEAD is not a merge commit — check for version bump after Git Flow finish
+        if current_branch == "develop":
+            try:
+                recent_msgs = subprocess.check_output(
+                    ["git", "log", "-5", "--format=%s", "HEAD"],
+                    stderr=subprocess.DEVNULL,
+                    text=True
+                ).strip()
+                if any(p in recent_msgs for p in ["release/", "hotfix/"]):
+                    sys.exit(0)
+            except subprocess.CalledProcessError:
+                pass
+
+# Check if command or current branch targets protected branches
+# Uses the parsed push_words from above to detect any form of protected branch targeting
+targets_protected = (
+    targets_protected_branch or
+    current_branch in ["main", "develop"]
+)
+
+# Block direct push to main/develop (including force pushes and refspec pushes)
+if targets_protected:
+    reason = f"""❌ Direct push to main/develop is not allowed!
+
+Protected branches:
+  - main (production)
+  - develop (integration)
+
+Git Flow workflow:
+  1. Create a feature branch:
+     git checkout -b feature/<name>
+
+  2. Make your changes and commit
+
+  3. Push feature branch:
+     git push origin feature/<name>
+
+  4. Create pull request:
+     gh pr create
+
+  5. After PR approval, merge via GitHub
+
+For releases:
+  git checkout -b release/v<version> develop
+  (prepare release, then merge to main + tag + merge back to develop)
+
+For hotfixes:
+  git checkout -b hotfix/<name> main
+  (fix + merge to main + tag + merge back to develop)
+
+Current branch: {current_branch}
+
+💡 If the superpowers plugin is installed, use /feature, /release, /hotfix, /finish for automated workflows."""
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+# Allow the command
+sys.exit(0)

--- a/.claude/hooks/require-preflight.py
+++ b/.claude/hooks/require-preflight.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Blocking Pre-Commit Hook: Requires Preflight Verification
+
+Installed by /harden-repo into target repo's .claude/hooks/
+
+This hook BLOCKS git commit commands unless a valid preflight token exists.
+Claude must run `./scripts/commit-preflight.sh` before committing.
+
+The token is:
+- Created by commit-preflight.sh after checks pass
+- Valid for 5 minutes
+- One-time use for regular commits (consumed after validation); reusable for --amend
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+
+
+def _get_token_path():
+    """Get project-specific token path using a hash of the project directory."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = os.path.realpath(project_dir)
+    project_hash = hashlib.md5(project_dir.encode()).hexdigest()[:8]
+    return f"/tmp/.preflight-token-{project_hash}"
+
+TOKEN_FILE = _get_token_path()
+
+
+def _targets_this_project(cmd: str) -> bool:
+    """Check if the command targets a repo within this project.
+
+    Hooks run in their own process (cwd = project dir), so git commands in
+    the hook inspect the wrong repo when Claude does 'cd /other/repo && git commit'.
+    Parse the cd target from the command to determine the effective repo.
+    """
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return True  # Can't determine scope, be safe
+
+    project_dir = os.path.realpath(project_dir)
+
+    # Extract the first "cd /path" from the command (handles "cd X && git commit")
+    cd_match = re.search(r'(?:^|[;&|]\s*)cd\s+("([^"]+)"|\'([^\']+)\'|(\S+))', cmd)
+    if cd_match:
+        target = cd_match.group(2) or cd_match.group(3) or cd_match.group(4)
+        target = os.path.expanduser(target)
+        target = os.path.expandvars(target)
+        target = os.path.realpath(target)
+        return os.path.commonpath([target, project_dir]) == project_dir
+
+    # No cd in command — assume it targets the project repo
+    return True
+
+
+def block(reason: str) -> None:
+    """Output a blocking decision."""
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+def allow() -> None:
+    """Allow the command to proceed."""
+    sys.exit(0)
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # Security gate must fail closed, not open
+        block("Preflight hook received invalid input. Blocking commit as a safety measure.")
+        return  # block() calls sys.exit(), but guard against refactoring
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only validate git commit commands
+    if tool_name != "Bash":
+        allow()
+        return
+
+    # Check if this is a git commit command
+    is_commit = "git commit" in command
+    is_amend = "--amend" in command
+
+    if not is_commit:
+        allow()
+        return
+
+    # Skip this hook if the command targets a repo outside this project
+    if not _targets_this_project(command):
+        allow()
+        return
+
+    # Check for skip flag (for emergencies - user must explicitly approve)
+    if "SKIP_PREFLIGHT=1" in command:
+        allow()
+        return
+
+    # Check if token file exists
+    if not os.path.exists(TOKEN_FILE):
+        block(f"""❌ COMMIT BLOCKED: Preflight verification required!
+
+You must run the preflight check before committing:
+
+    ./scripts/commit-preflight.sh
+
+This ensures:
+  ✓ Secret scanning passes
+  ✓ Lint passes (if configured)
+  ✓ Tests pass (if configured)
+
+The preflight creates a one-time token that allows the next commit.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Why this exists:
+  Claude previously ignored hook warnings and committed without
+  running tests. This mechanism ENFORCES the verification step.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Run: ./scripts/commit-preflight.sh
+Then retry your commit.""")
+
+    # Read and validate token
+    try:
+        with open(TOKEN_FILE, 'r') as f:
+            token_data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        # Token file corrupted - require new preflight
+        try:
+            os.remove(TOKEN_FILE)
+        except OSError as e:
+            print(f"Warning: Failed to remove corrupted token: {e}", file=sys.stderr)
+        block(f"""❌ COMMIT BLOCKED: Invalid preflight token!
+
+The token file is corrupted. Please run preflight again:
+
+    ./scripts/commit-preflight.sh
+
+Then retry your commit.""")
+
+    # Check token expiry
+    expires = token_data.get("expires", 0)
+    current_time = int(time.time())
+
+    if current_time > expires:
+        try:
+            os.remove(TOKEN_FILE)
+        except OSError as e:
+            print(f"Warning: Failed to remove expired token: {e}", file=sys.stderr)
+        time_ago = current_time - expires
+        block(f"""❌ COMMIT BLOCKED: Preflight token expired!
+
+Token expired {time_ago} seconds ago.
+
+Please run preflight again to refresh:
+
+    ./scripts/commit-preflight.sh
+
+Then retry your commit.""")
+
+    # Token is valid — consume for regular commits, preserve for amends
+    checks_run = token_data.get("checks_run", "none")
+    staged_count = token_data.get("staged_files", 0)
+
+    # For amend, we're more lenient — don't consume the token
+    if not is_amend:
+        try:
+            os.remove(TOKEN_FILE)
+        except OSError as e:
+            print(f"Warning: Failed to consume preflight token: {e}", file=sys.stderr)
+
+    # Token valid - allow commit
+    # Output verification status for audit trail
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": f"✅ Preflight verified: {checks_run} | {staged_count} files"
+        }
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/update-changelog-before-pr.py
+++ b/.claude/hooks/update-changelog-before-pr.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Pre-PR Hook: Block PR Creation Unless Changelog is Updated
+
+Installed by /harden-repo into target repo's .claude/hooks/
+
+This hook triggers before `gh pr create` commands. It BLOCKS the PR if
+CHANGELOG.md has no meaningful entries under [Unreleased], ensuring every
+PR includes a changelog update.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def get_branch_commits():
+    """Get commits on current branch not in origin/develop (or origin/main as fallback)."""
+    try:
+        cwd = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        # Detect base: prefer develop, fall back to main
+        for base in ["origin/develop", "origin/main"]:
+            check = subprocess.run(
+                ["git", "rev-parse", "--verify", base],
+                capture_output=True, text=True, cwd=cwd
+            )
+            if check.returncode == 0:
+                result = subprocess.run(
+                    ["git", "log", f"{base}..HEAD", "--oneline", "--no-merges"],
+                    capture_output=True, text=True, cwd=cwd
+                )
+                if result.returncode == 0:
+                    commits = result.stdout.strip().split('\n')
+                    return [c for c in commits if c]
+        return []
+    except Exception as e:
+        print(f"Warning: Failed to get branch commits: {e}", file=sys.stderr)
+        return []
+
+
+def check_changelog_modified_on_branch():
+    """Check if CHANGELOG.md was modified on the current branch vs base.
+
+    Returns (was_modified, base_branch_name). Returns (None, reason) if
+    the base branch cannot be determined or git comparison fails.
+    """
+    try:
+        cwd = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        # Check against develop first, fall back to main
+        for base in ["origin/develop", "origin/main"]:
+            check = subprocess.run(
+                ["git", "rev-parse", "--verify", base],
+                capture_output=True, text=True, cwd=cwd
+            )
+            if check.returncode == 0:
+                result = subprocess.run(
+                    ["git", "diff", "--name-only", f"{base}...HEAD", "--", "CHANGELOG.md"],
+                    capture_output=True, text=True, cwd=cwd
+                )
+                if result.returncode == 0:
+                    return bool(result.stdout.strip()), base
+                # Base exists but diff failed — don't fall through to wrong base
+                print(f"Warning: git diff against {base} failed: {result.stderr.strip()}", file=sys.stderr)
+                return None, f"git diff against {base} failed"
+        return None, "No base branch (origin/develop or origin/main) found"
+    except Exception as e:
+        print(f"Warning: Failed to check changelog branch modification: {e}", file=sys.stderr)
+        return None, f"git comparison failed: {e}"
+
+
+def _get_current_branch():
+    """Return the current git branch, or '' on error."""
+    try:
+        cwd = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, cwd=cwd
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as e:
+        print(f"Warning: Failed to get current branch: {e}", file=sys.stderr)
+    return ""
+
+
+def check_release_version_section(version):
+    """Check if CHANGELOG.md has a `## [version]` section with at least one entry.
+
+    Used when the PR is opened from a release/X.Y.Z or hotfix/X.Y.Z branch — the
+    release-prep commit moves [Unreleased] entries into [version], so requiring
+    [Unreleased] content would block every release PR.
+    """
+    try:
+        changelog_path = os.path.join(
+            os.environ.get("CLAUDE_PROJECT_DIR", "."),
+            "CHANGELOG.md"
+        )
+        if not os.path.exists(changelog_path):
+            return False, "CHANGELOG.md not found"
+        with open(changelog_path, 'r') as f:
+            content = f.read()
+        pattern = (
+            r'## \[v?' + re.escape(version) + r'\][^\n]*\r?\n'
+            r'(.*?)(?=\r?\n## \[|\Z)'
+        )
+        m = re.search(pattern, content, re.DOTALL)
+        if not m:
+            return False, f"[{version}] section not found in CHANGELOG.md"
+        body = m.group(1)
+        entries = [line.strip() for line in body.split('\n')
+                   if line.strip().startswith('- ')]
+        if entries:
+            return True, f"{len(entries)} entries found under [{version}]"
+        return False, f"[{version}] section has no entries"
+    except (PermissionError, OSError) as e:
+        return None, f"Cannot read CHANGELOG.md: {e}"
+    except Exception as e:
+        return None, f"Unexpected error checking changelog: {e}"
+
+
+def _release_version_from_branch(branch):
+    """Extract X.Y.Z version if branch is release/X.Y.Z or hotfix/X.Y.Z, else ''."""
+    m = re.match(r'^(?:release|hotfix)/v?(\d+\.\d+\.\d+(?:[-.][\w.]+)?)$', branch)
+    return m.group(1) if m else ""
+
+
+def check_changelog_has_unreleased_entries():
+    """Check if CHANGELOG.md has meaningful NEW entries under [Unreleased]."""
+    try:
+        changelog_path = os.path.join(
+            os.environ.get("CLAUDE_PROJECT_DIR", "."),
+            "CHANGELOG.md"
+        )
+        if not os.path.exists(changelog_path):
+            return False, "CHANGELOG.md not found"
+
+        with open(changelog_path, 'r') as f:
+            content = f.read()
+
+        # `[ \t]*\r?\n` tolerates trailing spaces / CRLF after the header but
+        # does NOT swallow blank lines — the original `\s*\n` was greedy enough
+        # to consume the blank separator before the next release header, which
+        # positioned the capture inside the NEXT section and counted its
+        # `- ` bullets as Unreleased entries (silent fail-open).
+        unreleased_match = re.search(r'## \[Unreleased\][ \t]*\r?\n(.*?)(?=\r?\n## \[|\Z)', content, re.DOTALL)
+        if not unreleased_match:
+            # Distinguish "header missing" from "header present but malformed"
+            # so the error message points at the real problem.
+            if re.search(r'## \[Unreleased\]', content):
+                return False, "[Unreleased] header found but not followed by a newline (check for trailing whitespace beyond spaces/tabs)"
+            return False, "[Unreleased] section not found in CHANGELOG.md"
+
+        unreleased_body = unreleased_match.group(1)
+
+        # Check if there are any list items (actual entries) under [Unreleased]
+        # List items start with "- " after optional whitespace
+        entries = [line.strip() for line in unreleased_body.split('\n')
+                   if line.strip().startswith('- ')]
+
+        if not entries:
+            return False, "[Unreleased] section has no entries"
+
+        # Entries exist — but are they new on this branch or stale?
+        modified, base_or_reason = check_changelog_modified_on_branch()
+        if modified is None:
+            # Fail-closed: if we can't verify entries are fresh, block
+            return False, (
+                f"[Unreleased] has {len(entries)} entries, but could not verify "
+                f"they were added on this branch ({base_or_reason}). "
+                f"Please ensure CHANGELOG.md is modified on this branch, then retry."
+            )
+        elif modified:
+            return True, f"{len(entries)} entries found under [Unreleased] (modified on this branch)"
+        else:
+            # Entries exist but CHANGELOG.md wasn't modified on this branch — stale
+            return False, (
+                f"[Unreleased] has {len(entries)} entries, but CHANGELOG.md was NOT "
+                f"modified on this branch (compared to {base_or_reason}). "
+                f"These entries were not added on this branch. "
+                f"Add a new entry for your changes."
+            )
+    except (PermissionError, OSError) as e:
+        return None, f"Cannot read CHANGELOG.md: {e}"
+    except Exception as e:
+        return None, f"Unexpected error checking changelog: {e}"
+
+
+def get_pr_base_branch(command):
+    """Extract the --base branch from gh pr create command, default to develop."""
+    base_match = re.search(r'--base(?:\s+|=)(\S+)', command)
+    if base_match:
+        return base_match.group(1)
+    return "develop"  # default base for Git Flow
+
+
+def block(reason):
+    """Block the PR creation."""
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+def add_context(message):
+    """Add advisory context without blocking."""
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": message
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+def _targets_this_project(cmd):
+    """Check if the command targets a repo within this project."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return True
+    project_dir = os.path.realpath(project_dir)
+    cd_match = re.search(r'(?:^|[;&|]\s*)cd\s+("([^"]+)"|\'([^\']+)\'|(\S+))', cmd)
+    if cd_match:
+        target = cd_match.group(2) or cd_match.group(3) or cd_match.group(4)
+        target = os.path.expanduser(target)
+        target = os.path.expandvars(target)
+        target = os.path.realpath(target)
+        return os.path.commonpath([target, project_dir]) == project_dir
+    return True
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        block("Changelog hook received invalid input. Blocking PR as a safety measure.")
+        return  # block() calls sys.exit(), but guard against refactoring
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only check for gh pr create commands
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    if "gh pr create" not in command:
+        sys.exit(0)
+
+    # Skip if targeting a different repo
+    if not _targets_this_project(command):
+        sys.exit(0)
+
+    # Release/hotfix PRs: the release-prep commit moves [Unreleased] entries
+    # into a versioned section — that IS the changelog update. Accept either
+    # [Unreleased] entries OR a populated [X.Y.Z] section matching the branch.
+    release_version = _release_version_from_branch(_get_current_branch())
+    if release_version:
+        has_release, release_reason = check_release_version_section(release_version)
+        if has_release is True:
+            add_context(f"✅ Changelog check (release branch): {release_reason}")
+
+    # Check if changelog has entries under [Unreleased]
+    has_entries, reason = check_changelog_has_unreleased_entries()
+
+    # None means filesystem error — block with the actual error, not changelog instructions
+    if has_entries is None:
+        block(f"❌ PR BLOCKED: {reason}")
+    elif has_entries:
+        add_context(f"✅ Changelog check: {reason}")
+    else:
+        # Get commits for context in the error message
+        commits = get_branch_commits()
+        commit_count = len(commits)
+        commit_summary = '\n'.join(f"  - {c}" for c in commits[:5])
+        if commit_count > 5:
+            commit_summary += f"\n  ... and {commit_count - 5} more"
+
+        base = get_pr_base_branch(command)
+
+        block(f"""❌ PR BLOCKED: Changelog not updated!
+
+{reason}
+
+This PR targets '{base}' and has {commit_count} commit(s):
+{commit_summary}
+
+You MUST add entries under the [Unreleased] section in CHANGELOG.md
+before creating this PR.
+
+Example:
+  ## [Unreleased]
+
+  ### Added
+  - Description of new feature
+
+  ### Fixed
+  - Description of bug fix
+
+Update CHANGELOG.md, stage it, amend your commit, then retry.""")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate-branch-name.py
+++ b/.claude/hooks/validate-branch-name.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+PreToolUse Hook: Validate Git Flow Branch Naming
+
+Enforces branch naming conventions: feature/*, release/v*, hotfix/*.
+Validates semantic versioning for release branches.
+
+Installed by /harden-repo into target repo's .claude/hooks/
+"""
+import json
+import os
+import sys
+import re
+
+
+def _targets_this_project(cmd: str) -> bool:
+    """Check if the command targets a repo within this project.
+
+    Hooks run in their own process (cwd = project dir), so git commands in
+    the hook inspect the wrong repo when Claude does 'cd /other/repo && git checkout -b'.
+    Parse the cd target from the command to determine the effective repo.
+    """
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return True  # Can't determine scope, be safe
+
+    project_dir = os.path.realpath(project_dir)
+
+    cd_match = re.search(r'(?:^|[;&|]\s*)cd\s+("([^"]+)"|\'([^\']+)\'|(\S+))', cmd)
+    if cd_match:
+        target = cd_match.group(2) or cd_match.group(3) or cd_match.group(4)
+        target = os.path.expanduser(target)
+        target = os.path.expandvars(target)
+        target = os.path.realpath(target)
+        return os.path.commonpath([target, project_dir]) == project_dir
+
+    return True
+
+
+try:
+    input_data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Security gate must fail closed, not open
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "Branch name hook received invalid input. Blocking as a safety measure."
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+tool_name = input_data.get("tool_name", "")
+tool_input = input_data.get("tool_input", {})
+command = tool_input.get("command", "")
+
+# Only validate git checkout -b commands
+if tool_name != "Bash" or "git checkout -b" not in command:
+    sys.exit(0)
+
+# Skip if targeting a different repo
+if not _targets_this_project(command):
+    sys.exit(0)
+
+# Extract branch name
+match = re.search(r'git checkout -b\s+([^\s]+)', command)
+if not match:
+    sys.exit(0)
+
+branch_name = match.group(1).strip("'\"")  # Strip shell quotes
+
+# Allow main and develop branches
+if branch_name in ["main", "develop"]:
+    sys.exit(0)
+
+# Validate Git Flow naming convention
+if not re.match(r'^(feature|release|hotfix)/', branch_name):
+    reason = f"""❌ Invalid Git Flow branch name: {branch_name}
+
+Git Flow branches must follow these patterns:
+  • feature/<descriptive-name>
+  • release/v<MAJOR>.<MINOR>.<PATCH>
+  • hotfix/<descriptive-name>
+
+Examples:
+  ✅ feature/user-authentication
+  ✅ release/v1.2.0
+  ✅ hotfix/critical-security-fix
+
+Invalid:
+  ❌ {branch_name} (missing Git Flow prefix)
+  ❌ feat/something (use 'feature/' not 'feat/')
+  ❌ fix/bug (use 'hotfix/' not 'fix/')
+
+💡 Use Git Flow commands instead:
+  /feature <name>  - Create feature branch
+  /release <version> - Create release branch
+  /hotfix <name>   - Create hotfix branch"""
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+# Validate release version format
+if branch_name.startswith("release/"):
+    if not re.match(r'^release/v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$', branch_name):
+        reason = f"""❌ Invalid release version: {branch_name}
+
+Release branches must follow semantic versioning:
+  release/vMAJOR.MINOR.PATCH[-prerelease]
+
+Valid examples:
+  ✅ release/v1.0.0
+  ✅ release/v2.1.3
+  ✅ release/v1.0.0-beta.1
+
+Invalid:
+  ❌ release/1.0.0 (missing 'v' prefix)
+  ❌ release/v1.0 (incomplete version)
+  ❌ {branch_name}
+
+💡 Use: /release v1.2.0"""
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason
+            }
+        }
+        print(json.dumps(output))
+        sys.exit(0)
+
+# Allow the command
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 .claude/hooks/prevent-direct-push.py", "timeout": 10 } ] },
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 .claude/hooks/require-preflight.py", "timeout": 10 } ] },
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 .claude/hooks/validate-branch-name.py", "timeout": 10 } ] },
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 .claude/hooks/update-changelog-before-pr.py", "timeout": 10 } ] }
+    ]
+  }
+}

--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -2,7 +2,7 @@ name: Validate Skills & Plugins
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   validate-skills:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
 *.swp
 *~
-.claude/
+.claude/settings.local.json
 plugins/obsidian-brain/.coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ Each skill also maintains its own `CHANGELOG.md` within its directory.
 
 Format: Monorepo-level events only. For per-skill change details, see `<skill>/CHANGELOG.md`.
 
+## [3.11.0] - 2026-06-01
+
+### Changes
+
+- chore: harden repo — added Git Flow (develop branch + rules), quality-gate hooks, a commit preflight that validates changed skills/plugins, a git-tag-based release pipeline, and branch protection on `main` and `develop`
+- docs: refreshed README to reflect current skills & plugins — removed the extracted `git-flow` plugin (now its own repo) and corrected `obsidian-brain` to v2.5.1 / 18 skills
+
+### Skill Inventory (7 skills)
+
+- `changelog-keeper` v1.1.1 — Keeps CHANGELOG.md up to date by generating categorized entries from git commit history
+- `claudeception` v3.2.0 — Extracts reusable knowledge from work sessions and codifies it into Claude Code skills
+- `context-shield` v1.3.0 — Prevents context window overflow when processing large content (Figma designs, web pages, GitHub wikis, large codebases). Delegates token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed based on batch count
+- `conversation-search` v1.1.0 — Searches Claude Code conversation history in ~/.claude/projects/ by topic, date, branch, or project. Provides verbatim conversation content and AI-generated summaries
+- `figma-ui-designer` v3.2.0 — Interactive Figma UI design skill with UX-expert brainstorming, progress tracking, and design-to-code bridging. Spawns a specialized UX designer agent that researches real-world references before proposing design directions. Four workflows: (A) capture running app, (B) new project design, (C) enhancement mockup, (D) extract existing Figma designs as input for specs/plans/code
+- `skill-authoring` v2.6.0 — Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism
+- `worktree` v1.0.0 — Creates isolated git worktrees for parallel Claude Code sessions, each on its own branch
+
+### Plugin Inventory (12 plugins)
+
+- `context-bar` v1.0.0 — Color-coded context window usage bar for Claude Code statusline and /context-bar command
+- `context-shield` v1.3.0 — Prevents context window overflow by delegating token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed. Covers: documentation sites, code audits, dependency research, large PR reviews, competitive analysis, security advisories.
+- `custom-statusline` v1.3.0 — 4-tier adaptive statusline with icons for folder, git branch, and context usage
+- `figma-ui-designer` v3.1.0 — Interactive Figma UI design skill with brainstorming, progress tracking, and design-to-code bridging via Figma MCP
+- `obsidian-brain` v2.5.1 — Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata.
+- `product-video-creation` v2.0.0 — Creates polished, narrated product demo videos using Remotion with AI-crafted storytelling, real app screenshots, animated phone mockups, brand-aligned styling, TTS voiceover, and background music.
+- `skill-authoring` v2.3.0 — Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism
+- `skill-publishing` v4.0.0 — Plugin-first publishing for Claude Code skills. Auto-assembles and syncs plugins from plugin-manifest.json files. Also supports bare skills and individual repos
+- `smart-screen-recorder` v4.3.0 — AI-driven screen recording and demo production pipeline for macOS. Records screen + cursor, analyzes with AI vision, generates zoom scripts and voiceover narration, and produces polished demo videos.
+- `spec-creator` v2.3.0 — Creates detailed story specifications with TDD implementation steps, success metrics, Figma UX design gates, and vertical splitting from various inputs (plans, requirements, GitHub issues).
+- `spec-review` v2.1.0 — Reviews and enriches story specifications with codebase-verified sub-tasks, architecture alignment, design simplification, and API test plans.
+- `statusline-creator` v1.0.0 — Creates and customizes Claude Code statusline scripts from composable items
+
 ## [3.10.0] - 2026-05-16
 
 ### Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# claude-code-skills
+
+A monorepo of reusable Agent Skills and Plugins for Claude Code. Each skill lives
+in its own top-level directory (and is also published as a plugin under `plugins/`).
+
+## Git Flow Rules
+
+- Never commit directly to `main` or `develop` — use feature branches
+- Branch naming: `feature/*`, `release/*`, `hotfix/*`
+- Features branch from and merge to `develop`
+- Releases branch from `develop`, merge to both `main` and `develop`
+- Hotfixes branch from `main`, merge to both `main` and `develop`
+- Run `./scripts/commit-preflight.sh` before every commit
+- Git Flow slash commands are provided by the installed [`git-flow`](https://github.com/abhattacherjee/git-flow) plugin under the `git-flow:` namespace: `git-flow:feature`, `git-flow:release`, `git-flow:hotfix`, `git-flow:finish`, `git-flow:flow-status`
+
+## Validation
+
+- `scripts/validate-skill.sh` and `scripts/validate-plugin.sh` validate skill/plugin
+  structure; the same checks run in CI via `.github/workflows/validate-skill.yml`
+- Run validation before opening a PR

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Plugins bundle skills, commands, agents, and hooks into a single installable pac
 | [context-shield](./plugins/context-shield/) | 1.3.0 | 1 | 0 | Prevents context window overflow by delegating token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed. Covers: documentation sites, code audits, dependency research, large PR reviews, competitive analysis, security advisories. |
 | [custom-statusline](./plugins/custom-statusline/) | 1.3.0 | 1 | 0 | 4-tier adaptive statusline with icons for folder, git branch, and context usage |
 | [figma-ui-designer](./plugins/figma-ui-designer/) | 3.1.0 | 1 | 0 | Interactive Figma UI design skill with brainstorming, progress tracking, and design-to-code bridging via Figma MCP |
-| [git-flow](./plugins/git-flow/) | 2.0.0 | 1 | 5 | Git Flow branching workflow with slash commands and diagnostic tools |
-| [obsidian-brain](./plugins/obsidian-brain/) | 2.4.0 | 17 | 0 | Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata. |
+| [obsidian-brain](./plugins/obsidian-brain/) | 2.5.1 | 18 | 0 | Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata. |
 | [product-video-creation](./plugins/product-video-creation/) | 2.0.0 | 1 | 0 | Creates polished, narrated product demo videos using Remotion with AI-crafted storytelling, real app screenshots, animated phone mockups, brand-aligned styling, TTS voiceover, and background music. |
 | [skill-authoring](./plugins/skill-authoring/) | 2.3.0 | 1 | 0 | Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism |
 | [skill-publishing](./plugins/skill-publishing/) | 4.0.0 | 1 | 0 | Plugin-first publishing for Claude Code skills. Auto-assembles and syncs plugins from plugin-manifest.json files. Also supports bare skills and individual repos |
@@ -36,6 +35,8 @@ Plugins bundle skills, commands, agents, and hooks into a single installable pac
 | [spec-creator](./plugins/spec-creator/) | 2.3.0 | 1 | 0 | Creates detailed story specifications with TDD implementation steps, success metrics, Figma UX design gates, and vertical splitting from various inputs (plans, requirements, GitHub issues). |
 | [spec-review](./plugins/spec-review/) | 2.1.0 | 1 | 0 | Reviews and enriches story specifications with codebase-verified sub-tasks, architecture alignment, design simplification, and API test plans. |
 | [statusline-creator](./plugins/statusline-creator/) | 1.0.0 | 1 | 0 | Creates and customizes Claude Code statusline scripts from composable items |
+
+> **Note:** The `git-flow` plugin moved to its own repository — install via `/plugin marketplace add abhattacherjee/git-flow`.
 
 
 ### Install via Claude Code (Recommended)
@@ -141,4 +142,4 @@ These skills follow the **Agent Skills** standard — a `SKILL.md` file with YAM
 [MIT](LICENSE)
 
 ---
-*Last synced: 2026-04-16*
+*Last synced: 2026-06-01*

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# bump-version.sh — Semantic versioning for any project
+# Usage: ./scripts/bump-version.sh <major|minor|patch|X.Y.Z>
+#
+# Installed by /harden-repo
+# Version source: git tags (vX.Y.Z) — no in-repo version file.
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+print_info()    { echo -e "${BLUE}info${NC} $1"; }
+print_success() { echo -e "${GREEN}success${NC} $1"; }
+print_warning() { echo -e "${YELLOW}warning${NC} $1"; }
+print_error()   { echo -e "${RED}error${NC} $1"; }
+
+show_usage() {
+  echo "Usage: $0 <major|minor|patch|X.Y.Z>"
+  echo ""
+  echo "  major    Bump major version (1.0.0 -> 2.0.0)"
+  echo "  minor    Bump minor version (1.0.0 -> 1.1.0)"
+  echo "  patch    Bump patch version (1.0.0 -> 1.0.1)"
+  echo "  X.Y.Z    Set specific version"
+}
+
+TYPE=$1
+if [[ -z "$TYPE" ]]; then
+  print_error "Missing version type"
+  show_usage
+  exit 1
+fi
+
+# ══════════════════════════════════════════════════════════════
+# VERSION SOURCE — git tags (vX.Y.Z)
+# This repo tracks versions via annotated git tags, not a file.
+# ══════════════════════════════════════════════════════════════
+
+# Derive current version from the latest git tag (strips leading 'v')
+CURRENT_VERSION="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
+if [ -z "$CURRENT_VERSION" ]; then CURRENT_VERSION="0.0.0"; fi
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+  print_error "Could not determine current version from git tags"
+  exit 1
+fi
+print_info "Current version: $CURRENT_VERSION"
+
+# ── Calculate new version ─────────────────────────────────────
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$TYPE" in
+  major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  minor) NEW_VERSION="$MAJOR.$((MINOR + 1)).0" ;;
+  patch) NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+  *)
+    if [[ ! "$TYPE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      print_error "Invalid version format: $TYPE (expected X.Y.Z)"
+      exit 1
+    fi
+    NEW_VERSION="$TYPE"
+    ;;
+esac
+
+print_info "New version: $NEW_VERSION"
+
+# ── Update version files ─────────────────────────────────────
+
+# Version is tracked via git tags (vX.Y.Z); no in-repo version file to update.
+# The new tag is created by scripts/git-flow-finish.sh during the release flow.
+echo -e "${BLUE}info${NC}  Version source is git tags — no file to update. Next version: $NEW_VERSION"
+
+echo ""
+print_success "Version bumped from $CURRENT_VERSION to $NEW_VERSION"
+echo ""
+print_info "Next steps:"
+echo "  1. Update CHANGELOG.md with release notes"
+echo "  2. Stage version files + CHANGELOG.md"
+echo "  3. git commit -m \"chore(release): bump version to $NEW_VERSION\""

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# Commit Preflight Check
+# Must be run before git commit to verify quality checks pass.
+# Creates a one-time token that the require-preflight.py hook validates.
+#
+# Usage:
+#   ./scripts/commit-preflight.sh              # Full verification
+#   ./scripts/commit-preflight.sh --docs-only  # Skip tests for docs changes
+#   ./scripts/commit-preflight.sh --skip-tests "reason"  # Skip with reason
+#   ./scripts/commit-preflight.sh --auto       # Auto-detect if tests needed
+#
+# Installed by /harden-repo
+# Lint/test commands customized for this project during installation.
+
+set -e
+
+# Project-scoped token path (must match require-preflight.py)
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_HASH=$(python3 -c "import hashlib, sys; print(hashlib.md5(sys.argv[1].encode()).hexdigest()[:8])" "$(realpath "$PROJECT_DIR")")
+TOKEN_FILE="/tmp/.preflight-token-${PROJECT_HASH}"
+TOKEN_EXPIRY_SECONDS=300  # Token valid for 5 minutes
+
+# Parse arguments
+SKIP_TESTS=false
+SKIP_REASON=""
+AUTO_DETECT=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --docs-only)
+            SKIP_TESTS=true
+            SKIP_REASON="documentation-only changes"
+            shift
+            ;;
+        --skip-tests)
+            SKIP_TESTS=true
+            SKIP_REASON="$2"
+            shift 2
+            ;;
+        --auto)
+            AUTO_DETECT=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--docs-only | --skip-tests \"reason\" | --auto]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "🔍 Running commit preflight checks..."
+echo ""
+
+# Get staged files
+STAGED_FILES=$(git diff --cached --name-only 2>/dev/null || echo "")
+
+if [ -z "$STAGED_FILES" ]; then
+    echo "⚠️  No staged files. Stage files first with 'git add'"
+    exit 1
+fi
+
+echo "📁 Staged files:"
+echo "$STAGED_FILES" | head -10
+TOTAL=$(echo "$STAGED_FILES" | wc -l | tr -d ' ')
+if [ "$TOTAL" -gt 10 ]; then
+    echo "   ... and $((TOTAL - 10)) more"
+fi
+echo ""
+
+# Auto-detect if tests are needed
+if [ "$AUTO_DETECT" = true ]; then
+    NON_DOC_FILES=$(echo "$STAGED_FILES" | grep -vE '\.(md|txt|json|yaml|yml)$|^docs/|^specs/|^\.claude/|^README|^LICENSE|^\.gitignore' || true)
+    if [ -z "$NON_DOC_FILES" ]; then
+        echo "📄 Auto-detected: Documentation/config changes only"
+        SKIP_TESTS=true
+        SKIP_REASON="auto-detected docs/config only"
+    else
+        echo "🔧 Auto-detected: Code changes present - running tests"
+    fi
+    echo ""
+fi
+
+# Handle skip tests mode
+if [ "$SKIP_TESTS" = true ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "⏭️  SKIPPING TESTS"
+    echo "   Reason: $SKIP_REASON"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+    TIMESTAMP=$(date +%s)
+    STAGED_COUNT=$(echo "$STAGED_FILES" | wc -l | tr -d ' ')
+    python3 -c "
+import json, sys
+token = {
+    'created': int(sys.argv[1]),
+    'expires': int(sys.argv[1]) + int(sys.argv[2]),
+    'staged_files': int(sys.argv[3]),
+    'checks_run': 'skipped',
+    'skip_reason': sys.argv[4]
+}
+print(json.dumps(token, indent=4))
+" "$TIMESTAMP" "$TOKEN_EXPIRY_SECONDS" "$STAGED_COUNT" "$SKIP_REASON" > "$TOKEN_FILE"
+
+    echo "✅ PREFLIGHT PASSED (tests skipped)"
+    echo "📝 You may now run: git commit -m \"your message\""
+    echo ""
+    exit 0
+fi
+
+# Track what we checked
+CHECKS_RUN=""
+CHECKS_PASSED=true
+
+# ── Secret scanning (always runs) ────────────────────────────
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔐 Running secret scan..."
+if ./scripts/pre-commit.sh; then
+    CHECKS_RUN="${CHECKS_RUN}secrets,"
+else
+    echo "❌ Secret scan failed"
+    CHECKS_PASSED=false
+fi
+
+# ══════════════════════════════════════════════════════════════
+# LINT SECTION — customized by /harden-repo during installation
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📋 Running lint checks..."
+
+echo "⏭️  No linter detected — skipping lint"
+
+# ══════════════════════════════════════════════════════════════
+# TEST SECTION — customized by /harden-repo during installation
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🧪 Running tests..."
+
+# This repo's quality gate is the validate scripts. Mirror CI's changed-dirs
+# approach: validate ONLY the skill/plugin dirs that have staged changes.
+VALIDATE_FAILED=false
+VALIDATED_ANY=false
+SKILL_DIRS=""
+PLUGIN_DIRS=""
+
+# Derive the skill/plugin dirs to validate from the staged file list.
+for path in $STAGED_FILES; do
+    # Skill dir = nearest ancestor directory containing a SKILL.md.
+    dir="$(dirname "$path")"
+    while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/SKILL.md" ]; then
+            SKILL_DIRS="${SKILL_DIRS}${dir}"$'\n'
+            break
+        fi
+        dir="$(dirname "$dir")"
+    done
+
+    # Plugin dir = plugins/<name> when that dir has a plugin manifest.
+    case "$path" in
+        plugins/*/*)
+            plugin_dir="plugins/$(echo "$path" | cut -d/ -f2)"
+            if [ -f "$plugin_dir/.claude-plugin/plugin.json" ]; then
+                PLUGIN_DIRS="${PLUGIN_DIRS}${plugin_dir}"$'\n'
+            fi
+            ;;
+    esac
+done
+
+# Dedupe the dir sets.
+SKILL_DIRS="$(printf '%s' "$SKILL_DIRS" | grep -v '^$' | sort -u || true)"
+PLUGIN_DIRS="$(printf '%s' "$PLUGIN_DIRS" | grep -v '^$' | sort -u || true)"
+
+if [ -z "$SKILL_DIRS" ] && [ -z "$PLUGIN_DIRS" ]; then
+    echo "ℹ️  No skill/plugin changes staged — skipping validation"
+else
+    while IFS= read -r skill_dir; do
+        [ -z "$skill_dir" ] && continue
+        if [ -f "$skill_dir/SKILL.md" ]; then
+            VALIDATED_ANY=true
+            if ! ./scripts/validate-skill.sh "$skill_dir" > /dev/null 2>&1; then
+                echo "❌ Skill validation failed: $skill_dir"
+                VALIDATE_FAILED=true
+            fi
+        fi
+    done <<< "$SKILL_DIRS"
+
+    while IFS= read -r plugin_dir; do
+        [ -z "$plugin_dir" ] && continue
+        VALIDATED_ANY=true
+        if ! ./scripts/validate-plugin.sh "$plugin_dir" > /dev/null 2>&1; then
+            echo "❌ Plugin validation failed: $plugin_dir"
+            VALIDATE_FAILED=true
+        fi
+    done <<< "$PLUGIN_DIRS"
+
+    if [ "$VALIDATE_FAILED" = true ]; then
+        echo "❌ Validation failed"
+        CHECKS_PASSED=false
+    elif [ "$VALIDATED_ANY" = true ]; then
+        echo "✅ Staged skills and plugins pass validation"
+        CHECKS_RUN="${CHECKS_RUN}validate,"
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$CHECKS_PASSED" = false ]; then
+    echo "❌ PREFLIGHT FAILED - Fix errors before committing"
+    rm -f "$TOKEN_FILE"
+    exit 1
+fi
+
+# Create confirmation token
+TIMESTAMP=$(date +%s)
+TOKEN_DATA=$(cat <<EOF
+{
+    "created": $TIMESTAMP,
+    "expires": $((TIMESTAMP + TOKEN_EXPIRY_SECONDS)),
+    "staged_files": $(echo "$STAGED_FILES" | wc -l | tr -d ' '),
+    "checks_run": "${CHECKS_RUN%,}"
+}
+EOF
+)
+
+echo "$TOKEN_DATA" > "$TOKEN_FILE"
+
+echo ""
+echo "✅ PREFLIGHT PASSED"
+echo ""
+echo "Token created (expires in ${TOKEN_EXPIRY_SECONDS}s)"
+echo "📝 You may now run: git commit -m \"your message\""
+echo ""

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -1,0 +1,565 @@
+#!/usr/bin/env bash
+# git-flow-finish.sh — Complete Git Flow finish with merge, tag, and push
+# Handles: merge to main + tag + GitHub Release + merge to develop + version bump + cleanup
+#
+# Installed by /harden-repo
+#
+# Usage:
+#   ./scripts/git-flow-finish.sh <branch-type> <version> [--dry-run]
+#
+# Examples:
+#   ./scripts/git-flow-finish.sh hotfix v1.0.6
+#   ./scripts/git-flow-finish.sh release v2.0.0
+#   ./scripts/git-flow-finish.sh hotfix v1.0.6 --dry-run
+
+set -euo pipefail
+
+# ── Constants ──────────────────────────────────────────────────────
+REPO=""
+BRANCH_TYPE=""
+BRANCH_TYPE_CAPITALIZED=""
+VERSION=""
+VERSION_NUMBER=""
+SOURCE_BRANCH=""
+DRY_RUN=false
+MERGE_VIA_PR=false
+
+# ── Functions ──────────────────────────────────────────────────────
+
+usage() {
+  cat <<'USAGE'
+Usage: git-flow-finish.sh <branch-type> <version> [options]
+
+Arguments:
+  branch-type   "hotfix" or "release"
+  version       Version with v prefix (e.g., v1.0.6)
+
+Options:
+  --dry-run         Show what would be done without executing
+  --help, -h        Show this help message
+
+Examples:
+  git-flow-finish.sh hotfix v1.0.6
+  git-flow-finish.sh release v2.0.0
+  git-flow-finish.sh hotfix v1.0.6 --dry-run
+
+What this script does:
+  1. Merges the source branch to main (--no-ff)
+  2. Creates annotated tag on main (local)
+  3. Pushes main + creates GitHub Release (tag + release notes from CHANGELOG.md)
+  4. Merges source branch back to develop (--no-ff)
+  5. Bumps develop to next patch version
+  6. Pushes develop to remote
+  7. Deletes source branch (local + remote)
+  8. Verifies final state (including GitHub Release)
+
+Push Strategy:
+  Direct git push. The prevent-direct-push.py hook detects Git Flow
+  merge context (release/hotfix in commit history) and allows the push.
+
+USAGE
+  exit 0
+}
+
+log() { echo "  $1"; }
+log_ok() { echo "  ✅ $1"; }
+log_fail() { echo "  ❌ $1"; }
+log_skip() { echo "  ⏭️  $1"; }
+log_phase() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  $1"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+die() { log_fail "$1"; exit 1; }
+
+# Push a local branch to a remote ref.
+# The prevent-direct-push.py hook detects Git Flow merge context and allows these pushes.
+# Args: $1 = target ref (e.g., "main" or "develop"), $2 = local branch to push from
+push_ref() {
+  local TARGET_REF="$1"
+  local LOCAL_BRANCH="$2"
+  local COMMIT_SHA
+  COMMIT_SHA=$(git rev-parse "$LOCAL_BRANCH")
+
+  if $DRY_RUN; then
+    log "[dry-run] Would push $LOCAL_BRANCH ($COMMIT_SHA) to origin/$TARGET_REF"
+    return 0
+  fi
+
+  git push origin "$LOCAL_BRANCH:$TARGET_REF" || die "Failed to push to origin/$TARGET_REF"
+  git fetch origin "$TARGET_REF" 2>&1 || log "Warning: fetch after push failed for $TARGET_REF (non-fatal)"
+  log_ok "Pushed to origin/$TARGET_REF ($COMMIT_SHA)"
+}
+
+# Create a GitHub Release (which also creates the tag on the remote)
+create_github_release() {
+  local TAG_NAME="$1"
+  local NOTES_FILE
+
+  if $DRY_RUN; then
+    log "[dry-run] Would create GitHub Release $TAG_NAME on main"
+    return 0
+  fi
+
+  NOTES_FILE=$(mktemp)
+
+  # Extract the version's section from CHANGELOG.md
+  if [[ -f CHANGELOG.md ]]; then
+    awk -v ver="## [$VERSION_NUMBER]" '{
+      if (index($0, ver) == 1) { found = 1; next }
+      if (found == 1 && $0 ~ /^## \[/) exit
+      if (found == 1) print
+    }' CHANGELOG.md > "$NOTES_FILE"
+
+    # Strip empty leading lines
+    if [[ -s "$NOTES_FILE" ]]; then
+      sed -i.bak '/./,$!d' "$NOTES_FILE" && rm -f "${NOTES_FILE}.bak"
+    fi
+  fi
+
+  # Log extraction result for debugging
+  if [[ -s "$NOTES_FILE" ]]; then
+    local NOTES_LINES
+    NOTES_LINES=$(wc -l < "$NOTES_FILE" | tr -d ' ')
+    log "Extracted $NOTES_LINES lines from CHANGELOG.md"
+  fi
+
+  # Fallback if CHANGELOG.md missing or extraction yielded nothing
+  if [[ ! -s "$NOTES_FILE" ]]; then
+    cat > "$NOTES_FILE" <<EOF
+${BRANCH_TYPE_CAPITALIZED} ${TAG_NAME}
+
+See CHANGELOG.md for full details.
+EOF
+    log "Using fallback release notes (CHANGELOG.md extraction empty)"
+  fi
+
+  # gh release create also creates the tag on the remote — no separate API call needed
+  if gh release create "$TAG_NAME" \
+    --repo "$REPO" \
+    --target main \
+    --title "${BRANCH_TYPE_CAPITALIZED} ${TAG_NAME}" \
+    --notes-file "$NOTES_FILE" 2>&1; then
+    log_ok "Created GitHub Release $TAG_NAME"
+  else
+    # If the release already exists (e.g., partial re-run), update it
+    log "Release $TAG_NAME may already exist, attempting update..."
+    if ! gh release edit "$TAG_NAME" \
+      --repo "$REPO" \
+      --title "${BRANCH_TYPE_CAPITALIZED} ${TAG_NAME}" \
+      --notes-file "$NOTES_FILE" 2>&1; then
+      rm -f "$NOTES_FILE"
+      die "Failed to create or update GitHub Release for $TAG_NAME"
+    fi
+    log_ok "Updated existing GitHub Release $TAG_NAME"
+  fi
+
+  # Verify release body is populated (catches silent failures where notes weren't applied)
+  local BODY_LENGTH
+  BODY_LENGTH=$(gh release view "$TAG_NAME" --repo "$REPO" --json body --jq '.body | length' 2>/dev/null || echo "0")
+  if [[ "$BODY_LENGTH" -lt 50 ]]; then
+    log "Release body appears empty or minimal ($BODY_LENGTH chars), re-applying notes..."
+    gh release edit "$TAG_NAME" \
+      --repo "$REPO" \
+      --notes-file "$NOTES_FILE" 2>&1 || log_fail "Failed to re-apply release notes"
+    log_ok "Re-applied release notes to $TAG_NAME"
+  fi
+
+  rm -f "$NOTES_FILE"
+}
+
+# Fallback: merge source branch to main via PR when direct push is blocked by branch protection.
+# Creates PR, waits for CI, merges, and syncs local main.
+merge_main_via_pr() {
+  local PR_URL PR_NUMBER
+
+  log "Direct push to main blocked (branch protection?). Falling back to PR merge..."
+
+  # Go back to source branch (we were on main after failed push)
+  git reset --hard origin/main
+  git checkout "$SOURCE_BRANCH"
+
+  # Create PR
+  PR_URL=$(gh pr create \
+    --base main \
+    --head "$SOURCE_BRANCH" \
+    --repo "$REPO" \
+    --title "$BRANCH_TYPE_CAPITALIZED $VERSION" \
+    --body "$(cat <<EOF
+$BRANCH_TYPE_CAPITALIZED $VERSION
+
+Merged via git-flow-finish.sh (branch protection PR path).
+See CHANGELOG.md for full details.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)" 2>/dev/null) || die "Failed to create PR for $SOURCE_BRANCH → main"
+
+  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+  log_ok "Created PR #$PR_NUMBER: $SOURCE_BRANCH → main"
+
+  # gh pr checks --watch exits early / times out on long suites; use gh run
+  # watch instead. Filter by commit SHA (not branch) — branch filtering returns
+  # the last run on that branch, which is almost always a prior (green) run,
+  # and gh run watch --exit-status would exit immediately with that stale
+  # result, passing CI validation without actually watching the new run.
+  log "Waiting for CI checks on PR #$PR_NUMBER..."
+  local RUN_ID HEAD_SHA gh_err
+  local MAX_WAIT=30  # Max attempts (30 × 10s = 5 min). GitHub has a brief
+                     # race between PR creation and workflow dispatch.
+  local INTERVAL=10
+  local ATTEMPT=0
+  HEAD_SHA=$(git rev-parse HEAD)
+  gh_err=$(mktemp)
+
+  while [[ $ATTEMPT -lt $MAX_WAIT ]]; do
+    # Separate transient "no run yet" (exit 0, empty output) from real errors
+    # (auth, network, rate-limit) so we fail fast instead of waiting 5 minutes
+    # for a misleading "no run found" message.
+    if ! RUN_ID=$(gh run list --repo "$REPO" --commit "$HEAD_SHA" --limit 1 \
+                    --json databaseId --jq '.[0].databaseId' 2>"$gh_err"); then
+      local err_detail
+      err_detail=$(cat "$gh_err" 2>/dev/null)
+      rm -f "$gh_err"
+      die "gh run list failed: ${err_detail}. Check gh auth / network."
+    fi
+    if [[ -n "$RUN_ID" && "$RUN_ID" != "null" ]]; then
+      break
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$INTERVAL"
+  done
+  rm -f "$gh_err"
+
+  if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+    die "No CI run found for commit $HEAD_SHA after $((MAX_WAIT * INTERVAL))s. Check GitHub Actions."
+  fi
+
+  log "Found CI run #$RUN_ID, watching..."
+  # No 2>/dev/null — a watcher that crashes mid-poll (token expiry, API 5xx)
+  # must surface its error, otherwise die() below misleadingly blames CI.
+  if ! gh run watch "$RUN_ID" --repo "$REPO" --exit-status; then
+    die "CI checks failed on PR #$PR_NUMBER (run #$RUN_ID). Fix issues and re-run."
+  fi
+  log_ok "CI checks passed on PR #$PR_NUMBER"
+
+  # Squash merge PR — combines all commits into a single commit on main.
+  # Release notes are captured via GitHub Release (from CHANGELOG.md),
+  # not from the merge commit message, so squash is safe here.
+  gh pr merge "$PR_NUMBER" \
+    --repo "$REPO" \
+    --squash \
+    --delete-branch=false \
+    || die "Failed to merge PR #$PR_NUMBER"
+
+  log_ok "Squash-merged PR #$PR_NUMBER to main"
+
+  # Sync local main with remote
+  git checkout main
+  git pull origin main
+
+  MERGE_VIA_PR=true
+}
+
+# ── Parse Arguments ────────────────────────────────────────────────
+
+[[ $# -lt 1 ]] && usage
+[[ "$1" == "--help" || "$1" == "-h" ]] && usage
+[[ $# -lt 2 ]] && { echo "Error: Missing version argument"; usage; }
+
+BRANCH_TYPE="$1"
+VERSION="$2"
+shift 2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --help|-h) usage ;;
+    *) die "Unknown option: $1" ;;
+  esac
+  shift
+done
+
+# ── Validate Inputs ────────────────────────────────────────────────
+
+[[ "$BRANCH_TYPE" == "hotfix" || "$BRANCH_TYPE" == "release" ]] || die "branch-type must be 'hotfix' or 'release', got '$BRANCH_TYPE'"
+
+echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' || die "Version must follow semver (e.g., v1.0.6 or v1.0.6-beta.1), got '$VERSION'"
+
+VERSION_NUMBER="${VERSION#v}"
+SOURCE_BRANCH="${BRANCH_TYPE}/${VERSION}"
+
+# Detect source branch variations (hotfix/deps-v1.0.6 vs hotfix/v1.0.6)
+if ! git rev-parse --verify "$SOURCE_BRANCH" >/dev/null 2>&1; then
+  # Try with deps- prefix (common for dependabot hotfixes)
+  if git rev-parse --verify "${BRANCH_TYPE}/deps-${VERSION}" >/dev/null 2>&1; then
+    SOURCE_BRANCH="${BRANCH_TYPE}/deps-${VERSION}"
+  else
+    die "Source branch not found. Tried: ${BRANCH_TYPE}/${VERSION}, ${BRANCH_TYPE}/deps-${VERSION}"
+  fi
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null) || die "Failed to get repo name. Is gh authenticated?"
+
+# ── Verify Prerequisites ───────────────────────────────────────────
+
+log_phase "PRE-FLIGHT CHECKS"
+
+# Must be on the source branch
+CURRENT=$(git branch --show-current)
+if [[ "$CURRENT" != "$SOURCE_BRANCH" ]]; then
+  die "Must be on $SOURCE_BRANCH, currently on $CURRENT"
+fi
+
+# Working directory must be clean
+if [[ -n "$(git status --porcelain)" ]]; then
+  die "Working directory is not clean. Commit or stash changes first."
+fi
+
+# All commits must be pushed (verify upstream is configured first)
+if ! git rev-parse --abbrev-ref "@{u}" >/dev/null 2>&1; then
+  die "No upstream configured for $SOURCE_BRANCH. Push it first: git push -u origin $SOURCE_BRANCH"
+fi
+UNPUSHED=$(git log "@{u}..HEAD" --oneline 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$UNPUSHED" -gt 0 ]]; then
+  die "$UNPUSHED unpushed commits. Push them first: git push"
+fi
+
+log_ok "On $SOURCE_BRANCH, clean, all pushed"
+
+# Capitalize first letter (POSIX-compatible; ${VAR^} requires bash 4+ and macOS ships bash 3.2)
+BRANCH_TYPE_CAPITALIZED="$(echo "$BRANCH_TYPE" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
+
+# ── Phase 1: Merge to Main ────────────────────────────────────────
+
+log_phase "MERGE TO MAIN"
+
+if $DRY_RUN; then
+  log "[dry-run] Would merge $SOURCE_BRANCH into main"
+else
+  git checkout main
+  git pull origin main
+
+  git merge --no-ff "$SOURCE_BRANCH" -m "$(cat <<EOF
+Merge $SOURCE_BRANCH into main
+
+$BRANCH_TYPE_CAPITALIZED $VERSION
+
+See CHANGELOG.md for full details.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)" || die "Merge to main failed (conflict?)"
+
+  log_ok "Merged $SOURCE_BRANCH into main (local)"
+
+  # Try to push; if branch protection blocks it, fall back to PR merge
+  if PUSH_ERR=$(git push origin main:main 2>&1); then
+    log_ok "Pushed to origin/main"
+  else
+    log "Push to main failed: $PUSH_ERR"
+    merge_main_via_pr
+  fi
+fi
+
+# ── Phase 2: Create Tag ───────────────────────────────────────────
+
+log_phase "CREATE TAG"
+
+if $DRY_RUN; then
+  log "[dry-run] Would create tag $VERSION on main"
+else
+  git tag -a "$VERSION" -m "$BRANCH_TYPE_CAPITALIZED $VERSION" || die "Failed to create tag $VERSION"
+  log_ok "Created annotated tag $VERSION"
+fi
+
+# ── Phase 3: Create GitHub Release ───────────────────────────────
+
+log_phase "CREATE GITHUB RELEASE"
+
+# Push tag to remote (gh release create uses --target but having the tag pushed ensures annotated tag)
+if ! $DRY_RUN && ! $MERGE_VIA_PR; then
+  if ! git push origin "$VERSION" 2>&1; then
+    log "⚠️  Failed to push annotated tag $VERSION. GitHub Release will create a lightweight tag instead (less metadata)."
+  fi
+fi
+create_github_release "$VERSION"
+
+# ── Phase 4: Merge to Develop ─────────────────────────────────────
+
+log_phase "MERGE TO DEVELOP"
+
+if $DRY_RUN; then
+  log "[dry-run] Would merge $SOURCE_BRANCH into develop"
+else
+  git checkout develop
+  git pull origin develop
+
+  git merge --no-ff "$SOURCE_BRANCH" -m "$(cat <<EOF
+Merge $SOURCE_BRANCH back into develop
+
+Sync ${BRANCH_TYPE} artifacts from $VERSION:
+- Changelog with versioned section
+- Version bumps
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)" || die "Merge to develop failed (conflict?)"
+
+  log_ok "Merged $SOURCE_BRANCH into develop"
+
+  # Sync main's --no-ff merge commit into develop's ancestry.
+  # Without this, GitHub shows develop as "1 commit behind main" because
+  # the merge commit on main (e.g., "Merge hotfix/v1.0.9 into main") is
+  # not an ancestor of develop — even though file content is identical.
+  git fetch origin main
+  if git log origin/main --not HEAD --oneline | grep -q .; then
+    log "Syncing main merge commit into develop ancestry..."
+    if git merge origin/main -m "Merge main into develop (sync $VERSION merge commit)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"; then
+      log_ok "Develop ancestry now includes main's merge commit"
+    else
+      if ! git merge --abort 2>/dev/null; then
+        die "Merge to sync main into develop failed and could not be aborted. Working directory may be dirty. Run: git merge --abort && git merge origin/main"
+      fi
+      log "⚠️  Could not sync main merge commit into develop. Run manually: git merge origin/main"
+    fi
+  else
+    log_ok "Develop already includes all main commits"
+  fi
+fi
+
+# ── Phase 5: Bump Develop Version ─────────────────────────────────
+
+log_phase "BUMP DEVELOP VERSION"
+
+# Calculate next patch version
+MAJOR=$(echo "$VERSION_NUMBER" | cut -d. -f1)
+MINOR=$(echo "$VERSION_NUMBER" | cut -d. -f2)
+RAW_PATCH=$(echo "$VERSION_NUMBER" | cut -d. -f3)
+PATCH=$(echo "$RAW_PATCH" | cut -d- -f1)
+NEXT_PATCH=$((PATCH + 1))
+NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+log "Next development version: $NEXT_VERSION"
+
+if $DRY_RUN; then
+  log "[dry-run] Would bump to next patch version via bump-version.sh"
+else
+  if [[ -x "./scripts/bump-version.sh" ]]; then
+    ./scripts/bump-version.sh patch || die "bump-version.sh failed — aborting release finish"
+  else
+    log_skip "bump-version.sh not found — skip version bump"
+  fi
+
+  # Stage known version files. Explicit allowlist beats `git add -A`:
+  # it keeps runtime artifacts out of the dev-bump commit. Keep this list in
+  # sync with bump-version.sh targets. Add project-specific files here if needed.
+  for vf in .claude-plugin/plugin.json .claude-plugin/marketplace.json package.json pyproject.toml Cargo.toml version.txt; do
+    [ -f "$vf" ] && git add "$vf"
+  done
+
+  # Fail if bump-version.sh edited files outside the allowlist. We look at
+  # unstaged modifications + untracked files only — `git status --porcelain`
+  # would also surface the allowlisted files we just staged (`M ` entries)
+  # and fire on every normal release.
+  REMAINING_CHANGES="$({ git diff --name-only; git ls-files --others --exclude-standard; } 2>/dev/null)"
+  if [[ -n "$REMAINING_CHANGES" ]]; then
+    log_fail "bump-version.sh produced changes outside the version-file allowlist:"
+    echo "$REMAINING_CHANGES"
+    die "Update the version-file list in this script or stage the additional files"
+  fi
+  if ! git diff --cached --quiet; then
+    git commit -m "$(cat <<EOF
+chore(develop): bump version for next development cycle
+
+Previous ${BRANCH_TYPE}: $VERSION
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+    log_ok "Bumped to next patch and committed"
+  else
+    log_skip "No version files changed"
+  fi
+fi
+
+# ── Phase 6: Push Develop ─────────────────────────────────────────
+
+log_phase "PUSH DEVELOP"
+
+push_ref "develop" "develop"
+
+# ── Phase 7: Cleanup ──────────────────────────────────────────────
+
+log_phase "CLEANUP"
+
+if $DRY_RUN; then
+  log "[dry-run] Would delete $SOURCE_BRANCH (local + remote)"
+else
+  # Delete local branch (-D force because squash merge creates different SHA,
+  # so git branch -d fails with "not fully merged")
+  git branch -D "$SOURCE_BRANCH" 2>/dev/null && log_ok "Deleted local $SOURCE_BRANCH" || log_skip "Local $SOURCE_BRANCH already deleted"
+
+  # Delete remote branch via API (avoids push hook)
+  gh api "repos/$REPO/git/refs/heads/$SOURCE_BRANCH" -X DELETE 2>/dev/null && log_ok "Deleted remote $SOURCE_BRANCH" || log_skip "Remote $SOURCE_BRANCH already deleted"
+fi
+
+# ── Phase 8: Verify ───────────────────────────────────────────────
+
+log_phase "VERIFICATION"
+
+if $DRY_RUN; then
+  log "[dry-run] Would verify main, develop, and tag are in sync"
+else
+  VERIFY_FAILED=false
+
+  # Verify current branch
+  FINAL_BRANCH=$(git branch --show-current)
+  [[ "$FINAL_BRANCH" == "develop" ]] && log_ok "On develop branch" || { log_fail "Expected develop, on $FINAL_BRANCH"; VERIFY_FAILED=true; }
+
+  # Verify local = remote for develop
+  git fetch origin develop 2>/dev/null
+  LOCAL_SHA=$(git rev-parse develop)
+  REMOTE_SHA=$(git rev-parse origin/develop 2>/dev/null)
+  [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]] && log_ok "develop in sync (local = remote)" || { log_fail "develop out of sync: local=$LOCAL_SHA remote=$REMOTE_SHA"; VERIFY_FAILED=true; }
+
+  # Verify local = remote for main
+  git fetch origin main 2>/dev/null
+  LOCAL_MAIN=$(git rev-parse main)
+  REMOTE_MAIN=$(git rev-parse origin/main 2>/dev/null)
+  [[ "$LOCAL_MAIN" == "$REMOTE_MAIN" ]] && log_ok "main in sync (local = remote)" || { log_fail "main out of sync"; VERIFY_FAILED=true; }
+
+  # Verify GitHub Release (and tag) exists on remote
+  if gh release view "$VERSION" --repo "$REPO" --json tagName --jq '.tagName' >/dev/null 2>&1; then
+    log_ok "GitHub Release $VERSION exists on remote"
+  else
+    log_fail "GitHub Release $VERSION not found on remote"
+    VERIFY_FAILED=true
+  fi
+
+  if $VERIFY_FAILED; then
+    die "Verification failed — see errors above"
+  fi
+
+  log_ok "Develop ready for next development cycle"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Git Flow Finish Complete: $VERSION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  $SOURCE_BRANCH → main (GitHub Release $VERSION) → develop"
+echo "  develop bumped to $NEXT_VERSION"
+echo "  Source branch deleted (local + remote)"
+echo ""
+if $DRY_RUN; then
+  echo "  [DRY RUN — no changes were made]"
+  echo ""
+fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Secret Detection Script
+# Scans staged files for potential secrets before commit.
+# Runs secret content scanning and filename checks.
+#
+# Installed by /harden-repo
+
+set -eo pipefail
+
+echo "🔍 Checking for secrets in staged files..."
+
+# Check for common secret patterns in added lines only (exclude scripts/, docs/, hooks, CI)
+# Scanning only '+' lines avoids blocking commits that remove leaked secrets.
+if ! STAGED_DIFF=$(git diff --cached -- ':!scripts/*' ':!docs/*' ':!*.md' ':!.claude/hooks/*' ':!.github/workflows/*' 2>&1); then
+  echo ""
+  echo "❌ ERROR: Failed to read staged diff for secret scanning."
+  exit 1
+fi
+
+if printf '%s\n' "$STAGED_DIFF" | grep '^+' | grep -v '^+++' | grep -E "(sk-[a-zA-Z0-9_-]{20,}|AKIA[0-9A-Z]{16}|private_key|-----BEGIN.*PRIVATE KEY-----|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82}|xox[bsapr]-[a-zA-Z0-9-]+|password\s*[:=]\s*['\"][^'\"]{8,})" 2>/dev/null; then
+  echo ""
+  echo "❌ ERROR: Potential secret detected in staged files!"
+  echo ""
+  echo "Found patterns that look like:"
+  echo "  - OpenAI API keys (sk-...)"
+  echo "  - AWS access keys (AKIA...)"
+  echo "  - Private keys (-----BEGIN...PRIVATE KEY-----)"
+  echo "  - GitHub tokens (ghp_..., gho_..., github_pat_...)"
+  echo "  - Slack tokens (xox...)"
+  echo "  - Password assignments"
+  echo ""
+  echo "Please remove secrets before committing."
+  echo "Use environment variables instead!"
+  exit 1
+fi
+
+# Check for .env files (except .env.example and .env.local.example)
+STAGED_ENV=$(git diff --cached --name-only | grep -E '\.env(\..+)?$' | grep -v '\.example$' || true)
+if [ -n "$STAGED_ENV" ]; then
+  echo ""
+  echo "❌ ERROR: Attempting to commit .env file(s)!"
+  echo ""
+  echo "The following .env files are staged:"
+  echo "$STAGED_ENV"
+  echo ""
+  echo "These files should NEVER be committed."
+  echo "Run: git reset HEAD <file>"
+  exit 1
+fi
+
+# Check for common secret filenames
+SECRET_FILES=$(git diff --cached --name-only | grep -E '(credentials\.json|serviceAccount\.json|\.pem$|\.key$|\.p12$|\.pfx$)' || true)
+if [ -n "$SECRET_FILES" ]; then
+  # Block truly binary secret containers that content scan cannot inspect
+  BINARY_SECRET_FILES=$(echo "$SECRET_FILES" | grep -E '\.(p12|pfx)$' || true)
+  if [ -n "$BINARY_SECRET_FILES" ]; then
+    echo ""
+    echo "❌ ERROR: Binary secret files staged (cannot be content-scanned):"
+    echo "$BINARY_SECRET_FILES"
+    echo ""
+    echo "These file types commonly contain private keys or certificates."
+    echo "Run: git reset HEAD <file>"
+    exit 1
+  fi
+
+  echo ""
+  echo "⚠️  WARNING: Potentially sensitive files staged:"
+  echo "$SECRET_FILES"
+  echo ""
+  echo "Verify these files do not contain secrets before committing."
+  # Warning only for non-binary files — content scan above catches actual secrets
+fi
+
+echo "✅ No secret content detected in staged diffs"


### PR DESCRIPTION
Release **v3.11.0** — repository hardening + documentation refresh. No skill or plugin versions changed this cycle.

## Changes
- **chore: harden repo** — Git Flow (`develop` + branching rules), quality-gate hooks, a commit preflight that validates only the *changed* skills/plugins, a git-tag-based release pipeline, and branch protection on `main` and `develop`.
- **docs: refresh README** — removed the extracted `git-flow` plugin (now its own repo, `abhattacherjee/git-flow`) and corrected `obsidian-brain` to v2.5.1 / 18 skills.

## Release mechanics
- Version source is **git tags**; the `v3.11.0` tag is created on merge via `/git-flow:finish` (no version file to bump).
- CHANGELOG `[3.11.0]` section added with carried-forward Skill (7) / Plugin (12) inventories.

## Follow-ups (not in this release)
- Pre-existing skill-validation debt tracked in #17, #18, #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)