### PR TITLE
chore: back-merge release/v3.11.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ Each skill also maintains its own `CHANGELOG.md` within its directory.
 
 Format: Monorepo-level events only. For per-skill change details, see `<skill>/CHANGELOG.md`.
 
+## [3.11.0] - 2026-06-01
+
+### Changes
+
+- chore: harden repo — added Git Flow (develop branch + rules), quality-gate hooks, a commit preflight that validates changed skills/plugins, a git-tag-based release pipeline, and branch protection on `main` and `develop`
+- docs: refreshed README to reflect current skills & plugins — removed the extracted `git-flow` plugin (now its own repo) and corrected `obsidian-brain` to v2.5.1 / 18 skills
+
+### Skill Inventory (7 skills)
+
+- `changelog-keeper` v1.1.1 — Keeps CHANGELOG.md up to date by generating categorized entries from git commit history
+- `claudeception` v3.2.0 — Extracts reusable knowledge from work sessions and codifies it into Claude Code skills
+- `context-shield` v1.3.0 — Prevents context window overflow when processing large content (Figma designs, web pages, GitHub wikis, large codebases). Delegates token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed based on batch count
+- `conversation-search` v1.1.0 — Searches Claude Code conversation history in ~/.claude/projects/ by topic, date, branch, or project. Provides verbatim conversation content and AI-generated summaries
+- `figma-ui-designer` v3.2.0 — Interactive Figma UI design skill with UX-expert brainstorming, progress tracking, and design-to-code bridging. Spawns a specialized UX designer agent that researches real-world references before proposing design directions. Four workflows: (A) capture running app, (B) new project design, (C) enhancement mockup, (D) extract existing Figma designs as input for specs/plans/code
+- `skill-authoring` v2.6.0 — Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism
+- `worktree` v1.0.0 — Creates isolated git worktrees for parallel Claude Code sessions, each on its own branch
+
+### Plugin Inventory (12 plugins)
+
+- `context-bar` v1.0.0 — Color-coded context window usage bar for Claude Code statusline and /context-bar command
+- `context-shield` v1.3.0 — Prevents context window overflow by delegating token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed. Covers: documentation sites, code audits, dependency research, large PR reviews, competitive analysis, security advisories.
+- `custom-statusline` v1.3.0 — 4-tier adaptive statusline with icons for folder, git branch, and context usage
+- `figma-ui-designer` v3.1.0 — Interactive Figma UI design skill with brainstorming, progress tracking, and design-to-code bridging via Figma MCP
+- `obsidian-brain` v2.5.1 — Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata.
+- `product-video-creation` v2.0.0 — Creates polished, narrated product demo videos using Remotion with AI-crafted storytelling, real app screenshots, animated phone mockups, brand-aligned styling, TTS voiceover, and background music.
+- `skill-authoring` v2.3.0 — Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism
+- `skill-publishing` v4.0.0 — Plugin-first publishing for Claude Code skills. Auto-assembles and syncs plugins from plugin-manifest.json files. Also supports bare skills and individual repos
+- `smart-screen-recorder` v4.3.0 — AI-driven screen recording and demo production pipeline for macOS. Records screen + cursor, analyzes with AI vision, generates zoom scripts and voiceover narration, and produces polished demo videos.
+- `spec-creator` v2.3.0 — Creates detailed story specifications with TDD implementation steps, success metrics, Figma UX design gates, and vertical splitting from various inputs (plans, requirements, GitHub issues).
+- `spec-review` v2.1.0 — Reviews and enriches story specifications with codebase-verified sub-tasks, architecture alignment, design simplification, and API test plans.
+- `statusline-creator` v1.0.0 — Creates and customizes Claude Code statusline scripts from composable items
+
 ## [3.10.0] - 2026-05-16
 
 ### Changes


### PR DESCRIPTION
Git Flow back-merge — brings the v3.11.0 CHANGELOG entry into develop after the release merged to main. No code changes beyond the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)