### PR TITLE
sync: v3.12.0 release back into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ Format: Monorepo-level events only. For per-skill change details, see `<skill>/C
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-06-02
+
 ### Added
 
-- adversarial-review plugin (v0.1.0) — Claude↔Gemini 3-round adversarial PR review with a both-confirm survivor rule; PR + local modes; loud degradation to Claude-only when the Gemini adversary is unavailable
+- adversarial-review plugin (v0.1.0) — Claude↔Gemini **symmetric** adversarial PR review: both models discover findings independently in round 1, then cross-examine each other's findings in round 2; only findings the opposing model confirms survive (both-confirm rule). Unconfirmed (single-model) and rejected (with refuter + reason) findings are always surfaced, never silently dropped. PR + local modes; loud degradation to Claude-only when the Gemini adversary is unavailable. Guided Gemini setup with headless-credential detection.
 
 ## [3.11.0] - 2026-06-01
 


### PR DESCRIPTION
Back-merge of the v3.12.0 release into develop (Git Flow). Lands the released CHANGELOG state on develop: empty [Unreleased] above the new [3.12.0] section with the corrected symmetric-pipeline wording. Counterpart to PR #26 (release into main). Opened via REST to work around the release-back-merge hook deadlock (tracked upstream).