### PR TITLE
fix(scripts): parse folded YAML descriptions; drop phantom /null commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: Monorepo-level events only. For per-skill change details, see `<skill>/C
 
 - **github-board-move** skill (v1.0.0) — moves an issue/PR's Project (v2) card to a target Status column (`scripts/board-move.sh`): board discovery, Status field/option lookup, fuzzy column matching, `--list-status`, `--dry-run`, `--add`, and the `updateProjectV2ItemFieldValue` mutation. Fills the mid-lifecycle gap between `create-gh-board` and `github-release-board-promote`. (#28)
 
+### Fixed
+
+- **Publishing scripts** — `validate-skill.sh` now parses folded YAML block-scalar descriptions (`description: >-`) by folding continuation lines, instead of reading only the `description:` line and failing the mandatory `Use when:` check on a 2-char value. `prepare-plugin.sh` no longer emits phantom `` `Command: /null` `` entries: the `seq 0 $((COUNT-1))` loops (which run twice at COUNT=0 under BSD/macOS `seq`) were replaced with C-style `for ((i=0; i<COUNT; i++))` loops. (#34)
+
 ## [3.12.0] - 2026-06-02
 
 ### Added

--- a/plugins/skill-publishing/skills/skill-publishing/scripts/prepare-plugin.sh
+++ b/plugins/skill-publishing/skills/skill-publishing/scripts/prepare-plugin.sh
@@ -155,7 +155,7 @@ fi
 if [[ $SKILL_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Skills ---"
-  for i in $(seq 0 $((SKILL_COUNT - 1))); do
+  for ((i=0; i<SKILL_COUNT; i++)); do
     SKILL_NAME_I=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
     SKILL_SRC=$(jq -r ".skills[$i].source" "$MANIFEST_FILE")
     SKILL_SRC=$(resolve_tilde "$SKILL_SRC")
@@ -189,7 +189,7 @@ fi
 if [[ $CMD_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Commands ---"
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CMD_NAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CMD_SRC=$(jq -r ".commands[$i].source" "$MANIFEST_FILE")
     CMD_SRC=$(resolve_tilde "$CMD_SRC")
@@ -213,7 +213,7 @@ fi
 if [[ $AGENT_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Agents ---"
-  for i in $(seq 0 $((AGENT_COUNT - 1))); do
+  for ((i=0; i<AGENT_COUNT; i++)); do
     AGENT_NAME=$(jq -r ".agents[$i].name" "$MANIFEST_FILE")
     AGENT_SRC=$(jq -r ".agents[$i].source" "$MANIFEST_FILE")
     AGENT_SRC=$(resolve_tilde "$AGENT_SRC")
@@ -309,14 +309,14 @@ Initial plugin release.
 - **$SKILL_COUNT skill(s)**, **$CMD_COUNT command(s)**"
 
   # Add skill names
-  for i in $(seq 0 $((SKILL_COUNT - 1))); do
+  for ((i=0; i<SKILL_COUNT; i++)); do
     SNAME=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
     CHANGELOG_CONTENT="$CHANGELOG_CONTENT
 - Skill: \`$SNAME\`"
   done
 
   # Add command names
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CNAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CHANGELOG_CONTENT="$CHANGELOG_CONTENT
 - Command: \`/$CNAME\`"
@@ -378,7 +378,7 @@ fi
 
 # --- Build Contents lists with descriptions ---
 SKILL_LIST=""
-for i in $(seq 0 $((SKILL_COUNT - 1))); do
+for ((i=0; i<SKILL_COUNT; i++)); do
   SNAME=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
   SSRC=$(jq -r ".skills[$i].source" "$MANIFEST_FILE")
   SSRC=$(resolve_tilde "$SSRC")
@@ -397,7 +397,7 @@ SKILL_LIST=$(echo "$SKILL_LIST" | sed '/./,$!d')
 CMD_LIST=""
 MANUAL_CMD_STEP=""
 if [[ $CMD_COUNT -gt 0 ]]; then
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CNAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CSRC=$(jq -r ".commands[$i].source" "$MANIFEST_FILE")
     CSRC=$(resolve_tilde "$CSRC")
@@ -418,7 +418,7 @@ fi
 
 AGENT_LIST=""
 if [[ $AGENT_COUNT -gt 0 ]]; then
-  for i in $(seq 0 $((AGENT_COUNT - 1))); do
+  for ((i=0; i<AGENT_COUNT; i++)); do
     ANAME=$(jq -r ".agents[$i].name" "$MANIFEST_FILE")
     ASRC=$(jq -r ".agents[$i].source" "$MANIFEST_FILE")
     ASRC=$(resolve_tilde "$ASRC")

--- a/plugins/skill-publishing/skills/skill-publishing/scripts/validate-skill.sh
+++ b/plugins/skill-publishing/skills/skill-publishing/scripts/validate-skill.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # validate-skill.sh — Validate a Claude Code skill directory against quality rules
+# NOTE: This validator is duplicated across skills (each <skill>/scripts/, the monorepo
+# root scripts/, and plugin bundles). Keep all copies byte-identical when editing.
 # Exit codes: 0 = pass, 1 = fail, 2 = usage error
 set -eu
 
@@ -93,7 +95,30 @@ get_frontmatter() {
 
 extract_field() {
   local field="$1"
-  get_frontmatter | grep "^${field}:" | head -1 | sed "s/^${field}:[[:space:]]*//; s/^[\"']//; s/[\"']$//"
+  local fm first val
+  fm="$(get_frontmatter)"
+  first="$(printf '%s\n' "$fm" | grep "^${field}:" | head -1)"
+  [[ -z "$first" ]] && return 0
+  val="$(printf '%s' "$first" | sed "s/^${field}:[[:space:]]*//")"
+  # YAML block scalar (>, >-, |, |-, etc.): fold the indented continuation lines into one
+  # space-joined string. Both > (fold) and | (literal) indicators are treated the same —
+  # only the text is needed for the length / "Use when:" / third-person checks, not exact
+  # newline semantics. Continuation lines are assumed uniformly indented: a non-indented
+  # line ends the block (per YAML), so a mis-indented line legitimately stops folding.
+  if printf '%s' "$val" | grep -qE '^[|>][0-9]*[+-]?[[:space:]]*(#.*)?$'; then
+    printf '%s\n' "$fm" | awk -v f="^${field}:" '
+      $0 ~ f { grab = 1; next }
+      grab {
+        if ($0 ~ /^[^[:space:]]/) exit        # non-indented line ends the block scalar
+        if ($0 ~ /^[[:space:]]*$/) next       # skip blank lines (avoid double spaces)
+        sub(/^[[:space:]]+/, "")
+        out = out (out == "" ? "" : " ") $0
+      }
+      END { print out }
+    '
+  else
+    printf '%s' "$val" | sed "s/^[\"']//; s/[\"']$//"
+  fi
 }
 
 extract_version() {

--- a/scripts/validate-skill.sh
+++ b/scripts/validate-skill.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # validate-skill.sh — Validate a Claude Code skill directory against quality rules
+# NOTE: This validator is duplicated across skills (each <skill>/scripts/, the monorepo
+# root scripts/, and plugin bundles). Keep all copies byte-identical when editing.
 # Exit codes: 0 = pass, 1 = fail, 2 = usage error
 set -eu
 
@@ -93,7 +95,30 @@ get_frontmatter() {
 
 extract_field() {
   local field="$1"
-  get_frontmatter | grep "^${field}:" | head -1 | sed "s/^${field}:[[:space:]]*//; s/^[\"']//; s/[\"']$//"
+  local fm first val
+  fm="$(get_frontmatter)"
+  first="$(printf '%s\n' "$fm" | grep "^${field}:" | head -1)"
+  [[ -z "$first" ]] && return 0
+  val="$(printf '%s' "$first" | sed "s/^${field}:[[:space:]]*//")"
+  # YAML block scalar (>, >-, |, |-, etc.): fold the indented continuation lines into one
+  # space-joined string. Both > (fold) and | (literal) indicators are treated the same —
+  # only the text is needed for the length / "Use when:" / third-person checks, not exact
+  # newline semantics. Continuation lines are assumed uniformly indented: a non-indented
+  # line ends the block (per YAML), so a mis-indented line legitimately stops folding.
+  if printf '%s' "$val" | grep -qE '^[|>][0-9]*[+-]?[[:space:]]*(#.*)?$'; then
+    printf '%s\n' "$fm" | awk -v f="^${field}:" '
+      $0 ~ f { grab = 1; next }
+      grab {
+        if ($0 ~ /^[^[:space:]]/) exit        # non-indented line ends the block scalar
+        if ($0 ~ /^[[:space:]]*$/) next       # skip blank lines (avoid double spaces)
+        sub(/^[[:space:]]+/, "")
+        out = out (out == "" ? "" : " ") $0
+      }
+      END { print out }
+    '
+  else
+    printf '%s' "$val" | sed "s/^[\"']//; s/[\"']$//"
+  fi
 }
 
 extract_version() {


### PR DESCRIPTION
## Summary
Fixes two defects in the publishing tooling found while publishing `deep-review` (#33).

### 1. `validate-skill.sh` couldn't parse folded YAML descriptions
`extract_field()` read only the single `description:` line, so a folded block scalar (`description: >-`) was captured as `>-` (~2 chars) → the mandatory `Use when:` check failed and `commit-preflight.sh` blocked the commit. It now detects YAML block-scalar indicators (`>`, `>-`, `|`, `|-`) and folds the indented continuation lines before validating.

### 2. `prepare-plugin.sh` emitted phantom `Command: /null` entries
`for i in $(seq 0 $((COUNT - 1)))` with `COUNT=0` becomes `seq 0 -1`, which on BSD/macOS `seq` emits `0` and `-1` (two iterations) → `jq` returned `"null"` twice. All 8 loops now use C-style `for ((i=0; i<COUNT; i++))`, a no-op when `COUNT=0`.

## Scope
Applied to the canonical validator (`scripts/validate-skill.sh`, used by CI + preflight) and the published `skill-publishing` plugin copies. The validator is also duplicated into every skill's `scripts/` dir — those refresh from the (already-fixed) source-of-record on the next sync and are intentionally not re-committed here (committing into `skill-authoring/` also trips its pre-existing, unrelated 615-line body-length validation failure).

## Verification
- Folded-description fixture → validator now PASSES
- Empty-commands manifest → generated CHANGELOG has 0 `/null` lines
- Regression: single-line quoted descriptions still validate
- `commit-preflight.sh` → PASS

## Follow-up (out of scope)
`skill-authoring`'s SKILL.md body is 615 lines (>500 max) and fails full validation independently of this change.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)