### PR TITLE
Release v3.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Reusable Agent Skills and Plugins for Claude Code",
-    "version": "2026.04.16"
+    "version": "2026.06.06"
   },
   "plugins": [
     {
       "name": "adversarial-review",
       "source": "./plugins/adversarial-review",
-      "description": "Adversarial PR review — Claude and Gemini independently discover findings in R1 then symmetrically cross-examine each other's findings in R2; only issues both models confirm survive. Auto-detects PR vs local (working-tree) mode; degrades loudly to Claude-only if the Gemini adversary is unavailable.",
+      "description": "Adversarial PR review — Claude and Gemini discover findings independently then cross-examine each other symmetrically, surfacing only issues both models confirm. Auto-detects PR vs local (working-tree) mode; degrades loudly to Claude-only if the Gemini adversary is unavailable.",
       "version": "0.1.0"
     },
     {
@@ -31,6 +31,12 @@
       "source": "./plugins/custom-statusline",
       "description": "4-tier adaptive statusline with icons for folder, git branch, and context usage",
       "version": "1.3.0"
+    },
+    {
+      "name": "deep-review",
+      "source": "./plugins/deep-review",
+      "description": "Two-phase convergence harness for high-assurance review of a changeset (PR or working-tree diff). Phase 1 loops iterative multi-reviewer fix->re-review until a round finds zero actionable issues; Phase 2 runs a Gemini-primary adversarial cross-examination (Gemini finds -> Claude judges -> Gemini counters), fixing every confirmed finding. Soft-depends on pr-review-toolkit and adversarial-review plugins with documented fallbacks.",
+      "version": "1.0.0"
     },
     {
       "name": "figma-ui-designer",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Each skill also maintains its own `CHANGELOG.md` within its directory.
 
 Format: Monorepo-level events only. For per-skill change details, see `<skill>/CHANGELOG.md`.
 
+## [2026-06-06] — Monorepo sync
+
+Synced 7 skills from local source.
+
+- `changelog-keeper` v1.1.1 — Keeps CHANGELOG.md up to date by generating categorized entries from git commit history
+- `claudeception` v3.2.0 — Extracts reusable knowledge from work sessions and codifies it into Claude Code skills
+- `context-shield` v1.3.0 — Prevents context window overflow when processing large content (Figma designs, web pages, GitHub wikis, large codebases). Delegates token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed based on batch count
+- `conversation-search` v1.1.0 — Searches Claude Code conversation history in ~/.claude/projects/ by topic, date, branch, or project. Provides verbatim conversation content and AI-generated summaries
+- `figma-ui-designer` v3.2.0 — Interactive Figma UI design skill with UX-expert brainstorming, progress tracking, and design-to-code bridging. Spawns a specialized UX designer agent that researches real-world references before proposing design directions. Four workflows: (A) capture running app, (B) new project design, (C) enhancement mockup, (D) extract existing Figma designs as input for specs/plans/code
+- `skill-authoring` v2.6.0 — Creates and optimizes Claude Code skills following Anthropic's official best practices with emphasis on agent parallelization and script-first determinism
+- `worktree` v1.0.0 — Creates isolated git worktrees for parallel Claude Code sessions, each on its own branch
+
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: Monorepo-level events only. For per-skill change details, see `<skill>/C
 
 - **github-board-move** skill (v1.0.0) — moves an issue/PR's Project (v2) card to a target Status column (`scripts/board-move.sh`): board discovery, Status field/option lookup, fuzzy column matching, `--list-status`, `--dry-run`, `--add`, and the `updateProjectV2ItemFieldValue` mutation. Fills the mid-lifecycle gap between `create-gh-board` and `github-release-board-promote`. (#28)
 
+### Fixed
+
+- **Publishing scripts** — `validate-skill.sh` now parses folded YAML block-scalar descriptions (`description: >-`) by folding continuation lines, instead of reading only the `description:` line and failing the mandatory `Use when:` check on a 2-char value. `prepare-plugin.sh` no longer emits phantom `` `Command: /null` `` entries: the `seq 0 $((COUNT-1))` loops (which run twice at COUNT=0 under BSD/macOS `seq`) were replaced with C-style `for ((i=0; i<COUNT; i++))` loops. (#34)
+
 ## [3.12.0] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: Monorepo-level events only. For per-skill change details, see `<skill>/C
 
 ## [Unreleased]
 
+### Added
+
+- **github-board-move** skill (v1.0.0) — moves an issue/PR's Project (v2) card to a target Status column (`scripts/board-move.sh`): board discovery, Status field/option lookup, fuzzy column matching, `--list-status`, `--dry-run`, `--add`, and the `updateProjectV2ItemFieldValue` mutation. Fills the mid-lifecycle gap between `create-gh-board` and `github-release-board-promote`. (#28)
+
 ## [3.12.0] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@ Synced 7 skills from local source.
 
 ## [Unreleased]
 
+## [3.13.0] - 2026-06-08
+
 ### Added
 
+- **deep-review** plugin (v1.0.0) — two-phase convergence harness for high-assurance changeset review: Phase 1 drives the `pr-review-toolkit` reviewers in fix→re-review rounds until they converge to zero actionable (Critical/Important) findings; Phase 2 runs an adversarial Claude↔Gemini cross-examination so only findings the *opposing* model confirms survive. Orchestrates the existing `pr-review-toolkit` and `adversarial-review` capabilities rather than reimplementing them, and degrades to Claude-only self-cross-examination (with a loud banner) when the Gemini adversary is unavailable. (#33)
 - **github-board-move** skill (v1.0.0) — moves an issue/PR's Project (v2) card to a target Status column (`scripts/board-move.sh`): board discovery, Status field/option lookup, fuzzy column matching, `--list-status`, `--dry-run`, `--add`, and the `updateProjectV2ItemFieldValue` mutation. Fills the mid-lifecycle gap between `create-gh-board` and `github-release-board-promote`. (#28)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Plugins bundle skills, commands, agents, and hooks into a single installable pac
 
 | Plugin | Version | Skills | Commands | Description |
 |--------|---------|--------|----------|-------------|
+| [adversarial-review](./plugins/adversarial-review/) | 0.1.0 | 1 | 0 | Adversarial PR review — Claude and Gemini discover findings independently then cross-examine each other symmetrically, surfacing only issues both models confirm. Auto-detects PR vs local (working-tree) mode; degrades loudly to Claude-only if the Gemini adversary is unavailable. |
 | [context-bar](./plugins/context-bar/) | 1.0.0 | 1 | 0 | Color-coded context window usage bar for Claude Code statusline and /context-bar command |
 | [context-shield](./plugins/context-shield/) | 1.3.0 | 1 | 0 | Prevents context window overflow by delegating token-heavy reads to isolated sub-agents that return distilled summaries. Auto-detects when ralph-loop is needed. Covers: documentation sites, code audits, dependency research, large PR reviews, competitive analysis, security advisories. |
 | [custom-statusline](./plugins/custom-statusline/) | 1.3.0 | 1 | 0 | 4-tier adaptive statusline with icons for folder, git branch, and context usage |
+| [deep-review](./plugins/deep-review/) | 1.0.0 | 1 | 0 | Two-phase convergence harness for high-assurance review of a changeset (PR or working-tree diff). Phase 1 loops iterative multi-reviewer fix->re-review until a round finds zero actionable issues; Phase 2 runs a Gemini-primary adversarial cross-examination (Gemini finds -> Claude judges -> Gemini counters), fixing every confirmed finding. Soft-depends on pr-review-toolkit and adversarial-review plugins with documented fallbacks. |
 | [figma-ui-designer](./plugins/figma-ui-designer/) | 3.1.0 | 1 | 0 | Interactive Figma UI design skill with brainstorming, progress tracking, and design-to-code bridging via Figma MCP |
 | [obsidian-brain](./plugins/obsidian-brain/) | 2.5.1 | 18 | 0 | Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata. |
 | [product-video-creation](./plugins/product-video-creation/) | 2.0.0 | 1 | 0 | Creates polished, narrated product demo videos using Remotion with AI-crafted storytelling, real app screenshots, animated phone mockups, brand-aligned styling, TTS voiceover, and background music. |
@@ -84,6 +86,7 @@ cp -r /tmp/claude-code-skills/claudeception ~/.claude/skills/claudeception
 cp -r /tmp/claude-code-skills/context-shield ~/.claude/skills/context-shield
 cp -r /tmp/claude-code-skills/conversation-search ~/.claude/skills/conversation-search
 cp -r /tmp/claude-code-skills/figma-ui-designer ~/.claude/skills/figma-ui-designer
+cp -r /tmp/claude-code-skills/github-board-move ~/.claude/skills/github-board-move
 cp -r /tmp/claude-code-skills/skill-authoring ~/.claude/skills/skill-authoring
 cp -r /tmp/claude-code-skills/worktree ~/.claude/skills/worktree
 rm -rf /tmp/claude-code-skills
@@ -142,4 +145,4 @@ These skills follow the **Agent Skills** standard — a `SKILL.md` file with YAM
 [MIT](LICENSE)
 
 ---
-*Last synced: 2026-06-01*
+*Last synced: 2026-06-06*

--- a/github-board-move/CHANGELOG.md
+++ b/github-board-move/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — github-board-move
+
+All notable changes to the **github-board-move** skill are documented here.
+
+## [1.0.0] - 2026-06-03
+
+### Added
+
+- Initial release. `scripts/board-move.sh` moves a GitHub issue/PR's Project (v2) card to a target Status column — board discovery, Status field/option lookup, fuzzy (exact → unique-substring) column matching, `--list-status`, `--dry-run`, `--add` (adds the card if missing), and a `project` auth-scope check. Reuses the proven GraphQL patterns from `github-release-board-promote`. (#28)

--- a/github-board-move/SKILL.md
+++ b/github-board-move/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: github-board-move
+description: "Moves a GitHub issue or PR's Project (v2) board card to a target Status column via a deterministic script (scripts/board-move.sh). Use when: (1) moving an issue to 'In Progress' when work starts, (2) moving a card to 'Development Complete'/'In Review'/'Done in develop' when its PR merges, (3) any mid-lifecycle Project v2 status change that github-release-board-promote (release->Done only) does not cover, (4) listing a board's available Status columns. Covers: projectsV2 board discovery, Status field/option lookup, updateProjectV2ItemFieldValue, fuzzy column matching, --add for items not yet on the board, project auth-scope checks."
+metadata:
+  version: 1.0.0
+---
+
+# GitHub Board Move
+
+## Problem
+Moving a Project (v2) card between Status columns mid-lifecycle (e.g. -> **In Progress** at work start, -> **Development Complete** when a PR merges) has no dedicated tool: `github-release-board-promote` only does release -> **Done**, and `create-gh-board` only builds boards. Otherwise the move means hand-writing `updateProjectV2ItemFieldValue` GraphQL each time.
+
+## Quick Check
+```bash
+# List the board's Status columns (names vary per board)
+./scripts/board-move.sh --list-status --repo OWNER/REPO
+
+# Move a card (fuzzy column match, case-insensitive)
+./scripts/board-move.sh --issue 28 --to "In Progress"
+./scripts/board-move.sh --pr 31 --to "Development Complete"
+
+# Preview without applying; add the card if it isn't on the board yet
+./scripts/board-move.sh --issue 9 --to done --dry-run
+./scripts/board-move.sh --issue 9 --to "Up Next" --add
+
+./scripts/board-move.sh --help
+```
+Defaults to the current repo and its single linked board; pass `--repo` / `--project <number>` to disambiguate.
+
+## When to use this vs other board skills
+| Need | Skill |
+|------|-------|
+| Move a card to any Status mid-lifecycle (In Progress, Dev Complete, In Review...) | **this skill** |
+| Promote shipped issues to **Done** after a release (validated, main-reachability guarded) | `github-release-board-promote` |
+| Create or replicate a board | `create-gh-board` |
+
+This is the tooling for steps 3 (-> In Progress) and 6 (-> post-merge column) of the standing GitHub project workflow.
+
+## Key facts
+- **Status column names are board-specific** — there is no canonical set. Run `--list-status` first. `--to` matches case-insensitively (exact, then unique substring); ambiguous or no match errors and prints the options.
+- **Auth scope:** discovery / `--list-status` / `--dry-run` need `read:project`; applying a move needs `project`. The script exits `3` with a `gh auth refresh -s project` hint if the write scope is missing.
+- **Projects v2 only** (GraphQL `projectsV2`). Classic (REST) projects are not supported.
+- **The option id is a plain string** — passed to the mutation via `gh api -f oid=` (not `-F`); a typed `-F` errors.
+- **The item must be on the board.** If the issue/PR is not a card yet, pass `--add` (runs `addProjectV2ItemById`); otherwise the script errors with that hint.
+- Idempotent — re-running for the same option is a no-op.
+
+## See Also
+- `github-release-board-promote` — release -> Done promotion (validated; main-reachability guarded)
+- `create-gh-board` — board creation / replication
+- `github-issue-triage` — issue audit, labeling, prioritization

--- a/github-board-move/scripts/board-move.sh
+++ b/github-board-move/scripts/board-move.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# board-move.sh — move a GitHub issue/PR's Project (v2) card to a target Status column.
+#
+# Mid-lifecycle companion to github-release-board-promote (which only does release -> Done).
+# Reuses the proven projectsV2 discovery + Status-field + updateProjectV2ItemFieldValue
+# pattern. Requires the gh CLI authenticated with the 'project' scope to apply a move.
+#
+set -euo pipefail
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+usage() {
+  cat <<'USAGE'
+board-move.sh — move an issue/PR's Project (v2) card to a target Status column.
+
+USAGE:
+  board-move.sh --issue <N> --to "<status>" [options]
+  board-move.sh --pr <N> --to "<status>" [options]
+  board-move.sh --list-status [options]
+
+OPTIONS:
+  --issue <N>         Issue number to move.
+  --pr <N>            PR number to move (mutually exclusive with --issue).
+  --to "<status>"     Target Status column. Matched case-insensitively: exact,
+                      then unique substring (e.g. "in prog" -> "In Progress").
+  --repo <owner/repo> Target repo (default: current repo via gh).
+  --project <number>  Board number (required only if the repo has >1 open board).
+  --add               Add the issue/PR to the board if it isn't already a card.
+  --list-status       Print the board's Status options and exit.
+  --dry-run           Show the resolved move without applying it.
+  -h, --help          This help.
+
+EXAMPLES:
+  board-move.sh --issue 28 --to "In Progress"
+  board-move.sh --pr 31 --to "Development Complete"
+  board-move.sh --issue 9 --to done --repo abhattacherjee/foo --project 7
+  board-move.sh --list-status
+
+EXIT CODES: 0 ok | 1 error | 2 usage | 3 missing gh 'project' auth scope
+USAGE
+  exit "${1:-2}"
+}
+
+REPO="" ISSUE="" PR="" TO="" PROJECT="" DRY_RUN=false ADD=false LIST=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue) ISSUE="${2:-}"; [[ -n "$ISSUE" ]] || usage 2; shift 2;;
+    --pr) PR="${2:-}"; [[ -n "$PR" ]] || usage 2; shift 2;;
+    --to) TO="${2:-}"; [[ -n "$TO" ]] || usage 2; shift 2;;
+    --repo) REPO="${2:-}"; [[ -n "$REPO" ]] || usage 2; shift 2;;
+    --project) PROJECT="${2:-}"; [[ -n "$PROJECT" ]] || usage 2; shift 2;;
+    --add) ADD=true; shift;;
+    --list-status) LIST=true; shift;;
+    --dry-run) DRY_RUN=true; shift;;
+    -h|--help) usage 0;;
+    *) echo "Unknown argument: $1" >&2; usage 2;;
+  esac
+done
+
+command -v gh >/dev/null || die "gh CLI not found."
+command -v jq >/dev/null || die "jq not found."
+
+# Auth scope. Every path hits the Projects API, so require at least read:project;
+# applying a move (not --list-status / --dry-run) additionally needs write 'project'.
+SCOPES=$(gh auth status 2>&1 | grep -i "Token scopes" || true)
+case "$SCOPES" in
+  *"read:project"*|*"'project'"*) ;;
+  *) echo "Error: gh token lacks a GitHub Projects scope (need at least read:project)." >&2
+     echo "Run: gh auth refresh -s read:project,project" >&2; exit 3;;
+esac
+if ! $LIST && ! $DRY_RUN; then
+  case "$SCOPES" in
+    *"'project'"*) ;;
+    *) echo "Error: gh token has read:project but not write 'project' (needed to modify a board)." >&2
+       echo "Run: gh auth refresh -s read:project,project" >&2; exit 3;;
+  esac
+fi
+
+# resolve repo
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner') || die "not in a GitHub repo; pass --repo owner/repo."
+fi
+OWNER=${REPO%/*}; NAME=${REPO#*/}
+
+gql() { gh api graphql -f query="$1" "${@:2}"; }
+
+# discover board
+if [[ -z "$PROJECT" ]]; then
+  BOARDS=$(gql 'query($o:String!,$n:String!){repository(owner:$o,name:$n){projectsV2(first:100){nodes{number title closed}}}}' \
+    -F o="$OWNER" -F n="$NAME" --jq '[.data.repository.projectsV2.nodes[]|select(.closed==false)]')
+  COUNT=$(echo "$BOARDS" | jq 'length')
+  [[ "$COUNT" -ge 1 ]] || die "no open Project (v2) board linked to $REPO."
+  if [[ "$COUNT" -gt 1 ]]; then
+    echo "Multiple boards linked to $REPO — pass --project <number>:" >&2
+    echo "$BOARDS" | jq -r '.[]|"  #\(.number) \(.title)"' >&2
+    exit 1
+  fi
+  PROJECT=$(echo "$BOARDS" | jq -r '.[0].number')
+fi
+[[ "$PROJECT" =~ ^[0-9]+$ ]] || die "--project must be a number (got: $PROJECT)."
+
+PID=$(gql 'query($o:String!,$n:String!,$p:Int!){repository(owner:$o,name:$n){projectV2(number:$p){id}}}' \
+  -F o="$OWNER" -F n="$NAME" -F p="$PROJECT" --jq '.data.repository.projectV2.id // empty')
+[[ -n "$PID" ]] || die "board #$PROJECT not found on $REPO."
+
+# Status field + options (exact 'Status', else first single-select named like status)
+FIELD_JSON=$(gql 'query($id:ID!){node(id:$id){... on ProjectV2{fields(first:50){nodes{... on ProjectV2SingleSelectField{id name options{id name}}}}}}}' \
+  -F id="$PID" --jq '.data.node.fields.nodes | map(select(.id!=null)) | (map(select((.name//"")|ascii_downcase=="status"))[0]) // empty')
+[[ -n "$FIELD_JSON" ]] || die "no single-select 'Status' field on board #$PROJECT."
+FID=$(echo "$FIELD_JSON" | jq -r '.id')
+
+if $LIST; then
+  echo "Status options on $REPO board #$PROJECT:"
+  echo "$FIELD_JSON" | jq -r '.options[]|"  - \(.name)"'
+  exit 0
+fi
+
+[[ -n "$TO" ]] || { echo "Error: --to <status> required." >&2; usage 2; }
+[[ -n "$ISSUE" || -n "$PR" ]] || { echo "Error: one of --issue/--pr required." >&2; usage 2; }
+[[ -n "$ISSUE" && -n "$PR" ]] && { echo "Error: --issue and --pr are mutually exclusive." >&2; usage 2; }
+
+# match target option: exact (ci) then unique substring (ci)
+OID=$(echo "$FIELD_JSON" | jq -r --arg t "$TO" '
+  .options as $o
+  | ([$o[]|select((.name|ascii_downcase)==($t|ascii_downcase))]) as $exact
+  | ([$o[]|select((.name|ascii_downcase)|contains($t|ascii_downcase))]) as $sub
+  | if ($exact|length)==1 then $exact[0].id
+    elif ($sub|length)==1 then $sub[0].id
+    else "" end')
+if [[ -z "$OID" ]]; then
+  echo "Error: --to \"$TO\" did not uniquely match a Status option. Available:" >&2
+  echo "$FIELD_JSON" | jq -r '.options[]|"  - \(.name)"' >&2
+  exit 1
+fi
+ONAME=$(echo "$FIELD_JSON" | jq -r --arg id "$OID" '.options[]|select(.id==$id).name')
+
+if [[ -n "$ISSUE" ]]; then KIND=issue; NUM="$ISSUE"; else KIND=pullRequest; NUM="$PR"; fi
+[[ "$NUM" =~ ^[0-9]+$ ]] || die "issue/PR number must be numeric (got: $NUM)."
+# Note: projectItems is capped at 100 (un-paginated). An item on >100 boards is not supported.
+CONTENT=$(gql "query(\$o:String!,\$n:String!,\$num:Int!){repository(owner:\$o,name:\$n){$KIND(number:\$num){id projectItems(first:100){nodes{id project{number}}}}}}" \
+  -F o="$OWNER" -F n="$NAME" -F num="$NUM")
+CONTENT_ID=$(echo "$CONTENT" | jq -r ".data.repository.$KIND.id // empty")
+[[ -n "$CONTENT_ID" ]] || die "$KIND #$NUM not found on $REPO."
+IID=$(echo "$CONTENT" | jq -r ".data.repository.$KIND.projectItems.nodes | map(select(.project.number==$PROJECT))[0].id // empty")
+
+if [[ -z "$IID" ]]; then
+  if ! $ADD; then
+    die "$KIND #$NUM is not a card on board #$PROJECT. Re-run with --add to add it first."
+  fi
+  if $DRY_RUN; then
+    echo "[dry-run] would add $KIND #$NUM to board #$PROJECT, then set Status -> \"$ONAME\"."
+    exit 0
+  fi
+  IID=$(gql 'mutation($pid:ID!,$cid:ID!){addProjectV2ItemById(input:{projectId:$pid,contentId:$cid}){item{id}}}' \
+    -F pid="$PID" -F cid="$CONTENT_ID" --jq '.data.addProjectV2ItemById.item.id // empty')
+  [[ -n "$IID" ]] || die "failed to add $KIND #$NUM to board #$PROJECT."
+  echo "Added $KIND #$NUM to board #$PROJECT."
+fi
+
+if $DRY_RUN; then
+  echo "[dry-run] would set $KIND #$NUM -> \"$ONAME\" on $REPO board #$PROJECT (item $IID)."
+  exit 0
+fi
+
+gql 'mutation($pid:ID!,$iid:ID!,$fid:ID!,$oid:String!){updateProjectV2ItemFieldValue(input:{projectId:$pid,itemId:$iid,fieldId:$fid,value:{singleSelectOptionId:$oid}}){projectV2Item{id}}}' \
+  -F pid="$PID" -F iid="$IID" -F fid="$FID" -f oid="$OID" --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null \
+  && echo "Moved $KIND #$NUM -> \"$ONAME\" on $REPO board #$PROJECT."

--- a/plugins/deep-review/.claude-plugin/plugin.json
+++ b/plugins/deep-review/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "deep-review",
+  "version": "1.0.0",
+  "description": "Two-phase convergence harness for high-assurance review of a changeset (PR or working-tree diff). Phase 1 loops iterative multi-reviewer fix->re-review until a round finds zero actionable issues; Phase 2 runs a Gemini-primary adversarial cross-examination (Gemini finds -> Claude judges -> Gemini counters), fixing every confirmed finding. Soft-depends on pr-review-toolkit and adversarial-review plugins with documented fallbacks."
+}

--- a/plugins/deep-review/.gitignore
+++ b/plugins/deep-review/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.swp
+*~
+.claude/

--- a/plugins/deep-review/CHANGELOG.md
+++ b/plugins/deep-review/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [1.0.0] - 2026-06-06
+
+Initial plugin release.
+
+### Included
+
+- **1 skill(s)**, **0 command(s)**
+- Skill: `deep-review`

--- a/plugins/deep-review/LICENSE
+++ b/plugins/deep-review/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Abhishek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/deep-review/README.md
+++ b/plugins/deep-review/README.md
@@ -1,0 +1,77 @@
+# deep-review
+
+Two-phase convergence harness for high-assurance review of a changeset (PR or working-tree diff). Phase 1 loops iterative multi-reviewer fix->re-review until a round finds zero actionable issues; Phase 2 runs a Gemini-primary adversarial cross-examination (Gemini finds -> Claude judges -> Gemini counters), fixing every confirmed finding. Soft-depends on pr-review-toolkit and adversarial-review plugins with documented fallbacks.
+
+## What It Does
+
+Runs two convergence phases on a PR or working-tree diff. Phase 1 dispatches specialized reviewers (general code, test coverage, silent-failure, type design, comments) in fix→re-review rounds until a full round finds zero actionable issues. Phase 2 runs a Gemini-primary adversarial cross-examination — Gemini finds, Claude judges, Gemini counters — so only findings the opposing model confirms survive, and every survivor is fixed and verified. The result is a changeset that passed both a depth gauntlet and a cross-model gauntlet.
+
+## Key Features
+
+- **Two-phase convergence** — an iterative multi-reviewer depth pass followed by an adversarial cross-model pass; the changeset must clear both gauntlets.
+- **Iterative review to zero issues** — specialized reviewers (code, tests, silent-failure, types, comments) run in fix→re-review rounds until a full round finds nothing actionable.
+- **Claude↔Gemini adversarial cross-examination** — both models discover findings independently, then judge each other's; only findings the opposing model confirms survive.
+- **Evidence-settled disputes** — refuted findings go to a counter-round where direct source evidence (not opinion) decides, and genuine judgment calls are escalated to you.
+- **Graceful degradation** — if Gemini isn't available it falls back to a second independent Claude reviewer as the adversary, with a loud banner that cross-model confirmation was skipped.
+- **PR or working-tree mode** — auto-targets an open PR's diff or local changes, with flags for phase selection (`--phase1-only`/`--phase2-only`) and `--max-rounds`.
+
+## Contents
+
+- **1** skill(s), **0** command(s)
+
+### Skills
+
+- `deep-review` — Two-phase iterative + adversarial review harness that converges a changeset to zero actionable, cross-model-confirmed issues.
+
+## Installation
+
+### Via Claude Code (Recommended)
+
+```shell
+# Add the marketplace (one-time setup)
+/plugin marketplace add abhattacherjee/claude-code-skills
+
+# Install this plugin
+/plugin install deep-review@claude-code-skills
+```
+
+### Via Script
+
+```bash
+git clone https://github.com/abhattacherjee/claude-code-skills.git /tmp/ccs
+/tmp/ccs/scripts/install-plugin.sh /tmp/ccs/plugins/deep-review
+rm -rf /tmp/ccs
+```
+
+### Manual
+
+```bash
+# Copy skills
+cp -r plugins/deep-review/skills/* ~/.claude/skills/
+
+```
+
+## Uninstall
+
+```bash
+# Via Claude Code
+/plugin uninstall deep-review@claude-code-skills
+
+# Via script
+git clone https://github.com/abhattacherjee/claude-code-skills.git /tmp/ccs
+/tmp/ccs/scripts/install-plugin.sh --uninstall /tmp/ccs/plugins/deep-review
+rm -rf /tmp/ccs
+```
+
+## Compatibility
+
+This plugin follows the **Claude Code Plugin** format. Skills use the **Agent Skills** standard recognized by:
+
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) (Anthropic)
+- [Cursor](https://www.cursor.com/)
+- [Codex CLI](https://github.com/openai/codex) (OpenAI)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) (Google)
+
+## License
+
+[MIT](LICENSE)

--- a/plugins/deep-review/skills/deep-review/SKILL.md
+++ b/plugins/deep-review/skills/deep-review/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: deep-review
+description: "Use when the user wants a thorough, high-assurance review of code changes — phrases like \"review this until it's clean\", \"converge to zero issues\", \"adversarial review\", \"have Gemini and Claude review\", \"deep review this PR\", or \"make this change ironclad\". Runs TWO phases on a PR or working-tree diff: (1) iterative multi-reviewer review that loops fix->re-review until a round finds zero actionable issues, then (2) a multi-round Gemini-primary adversarial cross-examination (Gemini finds -> Claude judges -> Gemini counters), fixing every confirmed finding. Repeatable across any project/PR. Use when: (1) the user wants a thorough, high-assurance review that converges to zero actionable issues, (2) the user asks for an adversarial or Gemini-and-Claude cross-examination review of a code diff, (3) deep-reviewing a PR or working-tree diff before merge, (4) the user wants to make a change ironclad."
+metadata:
+  version: 1.0.0
+---
+
+# Deep Review
+
+A two-phase convergence harness for high-assurance review of a changeset. Phase 1 drives
+specialized reviewers in fix->re-review rounds until they stop finding actionable issues. Phase 2
+runs an adversarial Claude<->Gemini cross-examination so only findings the *opposing* model confirms
+survive. The output is a changeset that passed both a depth gauntlet and a cross-model gauntlet,
+with every confirmed issue fixed and verified.
+
+**Announce at start:** "Using deep-review to run iterative + adversarial review to convergence."
+
+## When to use
+
+- The user wants more than a single review pass — they want *convergence* ("until it's clean").
+- High-stakes changes (security-sensitive, load-bearing guards, release candidates).
+- The user explicitly asks for adversarial / multi-model / Gemini review.
+
+Not for: a quick one-shot look (use `/pr-review-toolkit:review-pr` alone) or a trivial diff.
+
+## Arguments
+
+```
+/deep-review                 # auto: PR diff if branch has an open PR, else working-tree vs base
+/deep-review <PR#>           # target a specific PR
+/deep-review local           # force working-tree-vs-base mode
+/deep-review --phase1-only   # iterative review only (skip adversarial)
+/deep-review --phase2-only   # adversarial only (skip iterative)
+/deep-review --max-rounds N  # cap Phase-1 rounds (default 4)
+```
+
+## Prerequisites & composition
+
+This skill ORCHESTRATES two existing capabilities; it does not reimplement them:
+
+- **Phase 1** uses the `pr-review-toolkit` reviewer sub-agents
+  (`pr-review-toolkit:code-reviewer`, `:pr-test-analyzer`, `:silent-failure-hunter`,
+  `:type-design-analyzer`, `:comment-analyzer`). If that plugin is absent, fall back to the
+  `feature-dev:code-reviewer` / `Explore` agents or a `general-purpose` reviewer with the same
+  per-dimension prompts.
+- **Phase 2** uses the `adversarial-review` skill's engine + agents
+  (`adversarial-review:adversarial-bug-hunter`, `:adversarial-convention-reviewer`,
+  `:adversarial-cross-examiner`, and `scripts/gemini-review.sh`). If that plugin is absent, run the
+  pipeline manually per the steps below.
+
+Discover whether they're installed before relying on them; degrade with a stated fallback, never
+silently skip a phase.
+
+---
+
+## Phase 0 — Scope
+
+1. Establish repo + change scope:
+   - `git branch --show-current`; find an open PR for the branch (`gh pr list --head <branch>`).
+   - Default base = the PR base, else the repo default branch (`develop`/`main`).
+   - Build the diff: `git diff <base>...HEAD` (PR mode) or `git diff <base>` (local mode).
+2. Enumerate changed files and classify (code / tests / docs / config). This drives which
+   reviewers are applicable.
+3. **Include out-of-tree artifacts that are part of the same change-set** if the user mentions
+   them (e.g. live runtime config, instruction files not tracked in the repo). Reviewers should
+   judge the *whole* change, not just what git shows.
+4. Give every reviewer the **intent context** that isn't obvious from the diff (e.g. "this module
+   is deliberately retired", "this file is the live regression guard"). Grounding context prevents
+   wasted cycles re-flagging intentional decisions — but never use it to suppress a real defect.
+
+---
+
+## Phase 1 — Iterative review to convergence
+
+Loop until a full round produces **zero actionable (Critical/Important) issues from every
+dimension** AND the previous round's fixes introduced nothing new.
+
+### Each round
+
+1. **Dispatch applicable reviewers in parallel** (one message, multiple agents). Map dimensions to
+   the changed files: always run general code review; add test-coverage if tests changed,
+   silent-failure if error handling/guards changed, type-design if types added, comment/doc if
+   docs/comments changed. Each reviewer gets: the diff command, the file list, repo read access,
+   the intent context, and an instruction to **return findings grouped CRITICAL / IMPORTANT /
+   SUGGESTION with file:line + concrete fix**, and to **say so plainly if clean — do not invent
+   issues to seem thorough.**
+2. **Aggregate.** Deduplicate convergent findings (multiple reviewers flagging the same thing ->
+   higher confidence). Note which are factual vs judgment calls.
+3. **Fix** all Critical/Important via a single **implementer sub-agent** given the exact,
+   numbered fix spec (read-then-edit in its own context; this also sidesteps any parent-side
+   router restrictions on Read/Edit). Address cheap Suggestions too when they reduce future review
+   noise. The implementer must **verify empirically** — run the tests, and for any new guard/check,
+   **prove it fails-first** (a planted-regression that would pass even when the code is broken is a
+   silent defect; see Red Flags). Do not commit per-round by default — checkpoint at phase end to
+   avoid preflight churn.
+4. **Re-review (next round).** Re-query the same reviewers (continuing them via SendMessage
+   preserves their codebase context) with TWO asks: (a) verify each prior finding is *actually*
+   resolved against the new diff — not assumed; (b) check whether the fixes **introduced** any new
+   bug, inconsistency, or regression. A reviewer replies either with new CRITICAL/IMPORTANT items
+   or "CONVERGED — no actionable issues."
+5. **Converge or iterate.** If all dimensions report CONVERGED -> Phase 1 done. Else apply the new
+   fixes and run another round. Respect `--max-rounds` (default 4); if not converged at the cap,
+   surface the remaining items to the user rather than looping forever.
+
+### Phase 1 convergence is real only when
+
+- Every dimension returned CONVERGED in the SAME round, and
+- That round was a re-review *after* the latest fixes (so "converged" reflects the current tree),
+  and
+- Fixes were verified by running tests/build, not by inspection alone.
+
+Commit Phase 1 with a clear message summarizing rounds + classes of issues fixed. Follow the
+repo's commit discipline (run any preflight; if a hook requires preflight and commit as separate
+calls, do so; respect changelog/branch rules).
+
+---
+
+## Phase 2 — Multi-round Gemini-primary adversarial review
+
+Goal: cross-model confirmation. A finding only "survives" when the *opposing* model confirms it;
+single-model findings are retained as UNCONFIRMED, never silently dropped.
+
+### Step 2.0 — Ensure the adversary (Gemini)
+
+Run the adversarial-review skill's `ensure-gemini.sh --check` (or check `command -v gemini` +
+whether `~/.gemini/.env` has `GEMINI_API_KEY`). **Interactive Google login is NOT sufficient** —
+headless calls need an API key.
+
+- If Gemini is installed + headless-authed -> proceed.
+- **If not -> PROMPT THE USER at runtime** (this skill's chosen policy): offer to (a) install/auth
+  Gemini now (`npm i -g @google/gemini-cli`; add `GEMINI_API_KEY=<key>` to `~/.gemini/.env`), or
+  (b) proceed Claude-only (self-cross-examination: a second independent Claude agent judges the
+  first's findings) with a loud banner that cross-model confirmation was skipped. Do not decide
+  silently.
+
+### Step 2.1 — R1: blind parallel discovery
+
+In one message, launch (none seeing the others):
+- Claude bug-hunter (opus) — bugs/security/perf/correctness, grounded in source.
+- Claude convention-reviewer (sonnet) — convention/maintainability/doc-drift.
+- Gemini finder — `gemini-review.sh --diff <DIFF> --mode find` (or a direct
+  `gemini -p ... -o json -m gemini-2.5-pro` with the same brief).
+
+Give all the **byte-identical diff** (same-diff invariant). Merge Claude findings -> `C-001..`;
+Gemini -> `G-001..`. Emit an R1 digest (counts by severity/category). An empty findings array is a
+respectable, valid answer.
+
+### Step 2.2 — R2: symmetric cross-examination
+
+In one message:
+- Claude cross-examiner (opus) judges every Gemini finding -> `confirm|refute` with reason,
+  grounded in the **current** source (findings can be stale if Phase 1 already fixed them).
+- Gemini judges every Claude finding (`gemini-review.sh --mode judge`).
+
+Emit an R2 digest (confirmed/refuted/unjudged each direction).
+
+### Step 2.3 — R3: counter-round (the "let the primary counter" round)
+
+This is what makes it >=3 rounds and forces genuine convergence rather than a stalemate:
+- For each finding the opponent **refuted**, send it back to the originator to **concede or
+  defend**, grounded in source. Feed the refuter's reason and the relevant current file facts.
+- **Settle factual disputes with direct evidence, not opinion.** If one model claims "X already
+  exists / the catch is empty / the name has a space", run the actual `grep`/read and put the
+  evidence in front of both. Evidence ends the dispute (in this skill's origin run, a `grep` of
+  all check-name assignments settled a naming dispute and the primary conceded).
+- A judgment-call disagreement (e.g. keep-vs-delete dead code) can be legitimately *defended* by
+  either side on its real merits — if it stays split after evidence, escalate it to the user as an
+  explicit decision rather than forcing a verdict.
+
+### Step 2.4 — Converge (survivor rule)
+
+| Finding origin | Survives when |
+|---|---|
+| Claude (C-NNN) | Gemini confirms (R2), or concedes its refutation (R3) |
+| Gemini (G-NNN) | Claude confirms (R2), or concedes its refutation (R3) |
+
+- **Survivors** — both models agree -> fix them.
+- **Unconfirmed** — opponent abstained -> report, fix at discretion.
+- **Rejected** — opponent refuted and originator conceded -> record with reason; do not fix.
+
+If the adversarial-review skill is installed, `synthesize.py` applies this rule; otherwise apply it
+by hand and print `survivors / unconfirmed / rejected` counts.
+
+### Step 2.5 — Fix survivors + finalize
+
+Fix all survivors via an implementer sub-agent (same verify-empirically discipline as Phase 1).
+Then finalize:
+- Re-run the full test/build suite; confirm green.
+- **Sync any deployed/derived artifacts** the change affects (e.g. re-run an installer that copies
+  a test suite to a runtime location; regenerate a generated doc/architecture page). A repo's own
+  CLAUDE.md often mandates this in the same change-set.
+- Commit Phase 2 with a message naming the survivors and noting what the adversarial pass
+  dismissed (and why). Push; if the repo polls CI after push, check it.
+
+---
+
+## Final report
+
+Summarize for the user:
+- Phase 1: rounds run, count + classes of issues found and fixed, convergence confirmation.
+- Phase 2: R1 counts, what survived cross-examination, what was dismissed and why, any unresolved
+  judgment call escalated to them.
+- Verification evidence (test results, exit codes), commits/SHAs, push + CI status.
+
+## Red Flags — do not
+
+- **Declare convergence without a re-review after the last fix.** "Converged" must reflect the
+  current tree, in a round that ran *after* the fixes.
+- **Trust a finding-resolved claim without checking the diff.** Re-review verifies against source,
+  not memory. Likewise, a reviewer judging stale findings must read the *current* file.
+- **Accept a planted-regression test that can pass vacuously.** Every new guard/check needs a
+  fail-first negative: confirm the assertion FAILS when the code is broken. A test asserting on a
+  static string that's always present is the classic vacuous trap.
+- **Let the adversarial pass rubber-stamp.** The point is the *opposing* model. If running
+  Claude-only, use a genuinely independent second agent and say cross-model confirmation was
+  skipped.
+- **Silently drop a single-model finding.** Retain as UNCONFIRMED.
+- **Force a verdict on a genuine judgment call.** Escalate keep-vs-delete / design-taste splits to
+  the user.
+- **Fix in the parent context.** Dispatch an implementer sub-agent (clean context, no router
+  friction); the parent orchestrates.
+- **Skip syncing deployed artifacts** after changing a suite/config the runtime consumes.
+- **Hand a fix to re-review without self-checking it.** A new guard needs its planted-regression in the *same* edit; retiring/disabling/renaming code needs a sweep of *every* descriptor string (manifest, README tagline, comments), not just the banner — don't let the next round be the first to catch your fix's new gap.
+
+## Integration
+
+- `pr-review-toolkit:review-pr` — the per-dimension reviewers Phase 1 drives.
+- `adversarial-review:adversarial-review` — the Claude<->Gemini engine Phase 2 drives.
+- Repo `CLAUDE.md` — commit/branch/preflight discipline and any "keep X in sync" mandates.

--- a/plugins/skill-publishing/skills/skill-publishing/scripts/prepare-plugin.sh
+++ b/plugins/skill-publishing/skills/skill-publishing/scripts/prepare-plugin.sh
@@ -155,7 +155,7 @@ fi
 if [[ $SKILL_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Skills ---"
-  for i in $(seq 0 $((SKILL_COUNT - 1))); do
+  for ((i=0; i<SKILL_COUNT; i++)); do
     SKILL_NAME_I=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
     SKILL_SRC=$(jq -r ".skills[$i].source" "$MANIFEST_FILE")
     SKILL_SRC=$(resolve_tilde "$SKILL_SRC")
@@ -189,7 +189,7 @@ fi
 if [[ $CMD_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Commands ---"
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CMD_NAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CMD_SRC=$(jq -r ".commands[$i].source" "$MANIFEST_FILE")
     CMD_SRC=$(resolve_tilde "$CMD_SRC")
@@ -213,7 +213,7 @@ fi
 if [[ $AGENT_COUNT -gt 0 ]]; then
   echo ""
   echo "--- Agents ---"
-  for i in $(seq 0 $((AGENT_COUNT - 1))); do
+  for ((i=0; i<AGENT_COUNT; i++)); do
     AGENT_NAME=$(jq -r ".agents[$i].name" "$MANIFEST_FILE")
     AGENT_SRC=$(jq -r ".agents[$i].source" "$MANIFEST_FILE")
     AGENT_SRC=$(resolve_tilde "$AGENT_SRC")
@@ -309,14 +309,14 @@ Initial plugin release.
 - **$SKILL_COUNT skill(s)**, **$CMD_COUNT command(s)**"
 
   # Add skill names
-  for i in $(seq 0 $((SKILL_COUNT - 1))); do
+  for ((i=0; i<SKILL_COUNT; i++)); do
     SNAME=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
     CHANGELOG_CONTENT="$CHANGELOG_CONTENT
 - Skill: \`$SNAME\`"
   done
 
   # Add command names
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CNAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CHANGELOG_CONTENT="$CHANGELOG_CONTENT
 - Command: \`/$CNAME\`"
@@ -378,7 +378,7 @@ fi
 
 # --- Build Contents lists with descriptions ---
 SKILL_LIST=""
-for i in $(seq 0 $((SKILL_COUNT - 1))); do
+for ((i=0; i<SKILL_COUNT; i++)); do
   SNAME=$(jq -r ".skills[$i].name" "$MANIFEST_FILE")
   SSRC=$(jq -r ".skills[$i].source" "$MANIFEST_FILE")
   SSRC=$(resolve_tilde "$SSRC")
@@ -397,7 +397,7 @@ SKILL_LIST=$(echo "$SKILL_LIST" | sed '/./,$!d')
 CMD_LIST=""
 MANUAL_CMD_STEP=""
 if [[ $CMD_COUNT -gt 0 ]]; then
-  for i in $(seq 0 $((CMD_COUNT - 1))); do
+  for ((i=0; i<CMD_COUNT; i++)); do
     CNAME=$(jq -r ".commands[$i].name" "$MANIFEST_FILE")
     CSRC=$(jq -r ".commands[$i].source" "$MANIFEST_FILE")
     CSRC=$(resolve_tilde "$CSRC")
@@ -418,7 +418,7 @@ fi
 
 AGENT_LIST=""
 if [[ $AGENT_COUNT -gt 0 ]]; then
-  for i in $(seq 0 $((AGENT_COUNT - 1))); do
+  for ((i=0; i<AGENT_COUNT; i++)); do
     ANAME=$(jq -r ".agents[$i].name" "$MANIFEST_FILE")
     ASRC=$(jq -r ".agents[$i].source" "$MANIFEST_FILE")
     ASRC=$(resolve_tilde "$ASRC")

--- a/plugins/skill-publishing/skills/skill-publishing/scripts/validate-skill.sh
+++ b/plugins/skill-publishing/skills/skill-publishing/scripts/validate-skill.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # validate-skill.sh — Validate a Claude Code skill directory against quality rules
+# NOTE: This validator is duplicated across skills (each <skill>/scripts/, the monorepo
+# root scripts/, and plugin bundles). Keep all copies byte-identical when editing.
 # Exit codes: 0 = pass, 1 = fail, 2 = usage error
 set -eu
 
@@ -93,7 +95,30 @@ get_frontmatter() {
 
 extract_field() {
   local field="$1"
-  get_frontmatter | grep "^${field}:" | head -1 | sed "s/^${field}:[[:space:]]*//; s/^[\"']//; s/[\"']$//"
+  local fm first val
+  fm="$(get_frontmatter)"
+  first="$(printf '%s\n' "$fm" | grep "^${field}:" | head -1)"
+  [[ -z "$first" ]] && return 0
+  val="$(printf '%s' "$first" | sed "s/^${field}:[[:space:]]*//")"
+  # YAML block scalar (>, >-, |, |-, etc.): fold the indented continuation lines into one
+  # space-joined string. Both > (fold) and | (literal) indicators are treated the same —
+  # only the text is needed for the length / "Use when:" / third-person checks, not exact
+  # newline semantics. Continuation lines are assumed uniformly indented: a non-indented
+  # line ends the block (per YAML), so a mis-indented line legitimately stops folding.
+  if printf '%s' "$val" | grep -qE '^[|>][0-9]*[+-]?[[:space:]]*(#.*)?$'; then
+    printf '%s\n' "$fm" | awk -v f="^${field}:" '
+      $0 ~ f { grab = 1; next }
+      grab {
+        if ($0 ~ /^[^[:space:]]/) exit        # non-indented line ends the block scalar
+        if ($0 ~ /^[[:space:]]*$/) next       # skip blank lines (avoid double spaces)
+        sub(/^[[:space:]]+/, "")
+        out = out (out == "" ? "" : " ") $0
+      }
+      END { print out }
+    '
+  else
+    printf '%s' "$val" | sed "s/^[\"']//; s/[\"']$//"
+  fi
 }
 
 extract_version() {

--- a/scripts/validate-skill.sh
+++ b/scripts/validate-skill.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # validate-skill.sh — Validate a Claude Code skill directory against quality rules
+# NOTE: This validator is duplicated across skills (each <skill>/scripts/, the monorepo
+# root scripts/, and plugin bundles). Keep all copies byte-identical when editing.
 # Exit codes: 0 = pass, 1 = fail, 2 = usage error
 set -eu
 
@@ -93,7 +95,30 @@ get_frontmatter() {
 
 extract_field() {
   local field="$1"
-  get_frontmatter | grep "^${field}:" | head -1 | sed "s/^${field}:[[:space:]]*//; s/^[\"']//; s/[\"']$//"
+  local fm first val
+  fm="$(get_frontmatter)"
+  first="$(printf '%s\n' "$fm" | grep "^${field}:" | head -1)"
+  [[ -z "$first" ]] && return 0
+  val="$(printf '%s' "$first" | sed "s/^${field}:[[:space:]]*//")"
+  # YAML block scalar (>, >-, |, |-, etc.): fold the indented continuation lines into one
+  # space-joined string. Both > (fold) and | (literal) indicators are treated the same —
+  # only the text is needed for the length / "Use when:" / third-person checks, not exact
+  # newline semantics. Continuation lines are assumed uniformly indented: a non-indented
+  # line ends the block (per YAML), so a mis-indented line legitimately stops folding.
+  if printf '%s' "$val" | grep -qE '^[|>][0-9]*[+-]?[[:space:]]*(#.*)?$'; then
+    printf '%s\n' "$fm" | awk -v f="^${field}:" '
+      $0 ~ f { grab = 1; next }
+      grab {
+        if ($0 ~ /^[^[:space:]]/) exit        # non-indented line ends the block scalar
+        if ($0 ~ /^[[:space:]]*$/) next       # skip blank lines (avoid double spaces)
+        sub(/^[[:space:]]+/, "")
+        out = out (out == "" ? "" : " ") $0
+      }
+      END { print out }
+    '
+  else
+    printf '%s' "$val" | sed "s/^[\"']//; s/[\"']$//"
+  fi
 }
 
 extract_version() {


### PR DESCRIPTION
## Release v3.13.0

Cuts the monorepo release for the three feature merges accumulated on `develop` since **v3.12.0**.

### Added
- **deep-review** plugin (v1.0.0) — two-phase convergence harness: Phase 1 iterates the `pr-review-toolkit` reviewers to zero actionable findings; Phase 2 runs an adversarial Claude↔Gemini cross-examination where only opposing-model-confirmed findings survive. Orchestrates existing pr-review-toolkit + adversarial-review capabilities; degrades to Claude-only when Gemini is unavailable. (#33)
- **github-board-move** skill (v1.0.0) — moves an issue/PR's Project (v2) card to a target Status column; fills the mid-lifecycle gap between `create-gh-board` and `github-release-board-promote`. (#29)

### Fixed
- **Publishing scripts** — `validate-skill.sh` now folds `description: >-` block scalars (was failing the `Use when:` check on a 2-char value); `prepare-plugin.sh` no longer emits phantom `Command: /null` entries (BSD `seq 0 -1` two-line bug → C-style loops). (#35)

### Release mechanics
- Version bump is CHANGELOG-only (no VERSION/package.json; marketplace.json version is sync-managed).
- `[Unreleased]` → `[3.13.0] - 2026-06-08`.
- On merge: tag `v3.13.0`, then back-merge to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)